### PR TITLE
fix: show server error messages instead of generic HTTP status

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -239,11 +239,12 @@ async function handleGenerateClick(e) {
             body: formData,
         });
 
-        if (!response.ok) {
+        const data = await response.json();
+
+        // Check for HTTP errors, but use server message if available
+        if (!response.ok && !data) {
             throw new Error(`Server error: ${response.status}`);
         }
-
-        const data = await response.json();
 
         // Debug: log API response
         if (window.zwTTVGPT.debugMode) {

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -239,10 +239,15 @@ async function handleGenerateClick(e) {
             body: formData,
         });
 
-        const data = await response.json();
+        let data;
+        try {
+            data = await response.json();
+        } catch (parseError) {
+            throw new Error(`Server error: ${response.status}`);
+        }
 
         // Check for HTTP errors, but use server message if available
-        if (!response.ok && !data) {
+        if (!response.ok && !data?.data?.message) {
             throw new Error(`Server error: ${response.status}`);
         }
 


### PR DESCRIPTION
## Summary
- Parse JSON response before checking HTTP status code
- Display actual server error messages (e.g., "Te weinig woorden. Minimaal 100 vereist, 45 gevonden.") instead of generic "Server error: 400"

## Test plan
- [x] Test with article containing fewer than 100 words - should show word count error message
- [x] Test with valid article - should generate summary normally
- [ ] Test with network error - should show generic error