### PR TITLE
chore: simplify phpstan bootstrap (revert .stub workaround)

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,14 +1,18 @@
 <?php
 /**
- * PHPStan bootstrap stub - loaded by PHPStan only, never by WordPress.
+ * PHPStan bootstrap file - never loaded by WordPress.
  *
- * The .stub extension keeps this file outside WordPress plugin-check's scan
- * scope (which targets *.php only) while still being a valid PHP file that
- * PHPStan can require via bootstrapFiles. Release zips also exclude
- * phpstan-bootstrap.stub via wp-release.yml@v2's rsync exclude list.
+ * The canonical ABSPATH guard satisfies WordPress plugin-check's direct-access
+ * rule. PHPStan can still execute the rest of this file because
+ * szepeviktor/phpstan-wordpress runtime-defines ABSPATH in its extension
+ * bootstrap, so the guard short-circuits during analysis.
  *
  * @package ZW_TTVGPT
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 define( 'ZW_TTVGPT_VERSION', '1.0.0' );
 define( 'ZW_TTVGPT_DIR', __DIR__ . '/' );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
   excludePaths:
     - vendor
   bootstrapFiles:
-    - phpstan-bootstrap.stub
+    - phpstan-bootstrap.php
   parallel:
     maximumNumberOfProcesses: 1
   typeAliases:


### PR DESCRIPTION
Reverts the `phpstan-bootstrap.stub` workaround introduced when migrating to strict wp-templates. Turns out szepeviktor/phpstan-wordpress runtime-defines `ABSPATH` in its extension bootstrap, so the canonical `if ( ! defined( 'ABSPATH' ) ) { exit; }` guard short-circuits during PHPStan analysis (ABSPATH is already defined) while still satisfying plugin-check's direct-access rule.

## What changed

- Renamed `phpstan-bootstrap.stub` back to `phpstan-bootstrap.php` and added the canonical guard.
- Updated `phpstan.neon` bootstrapFiles path.

## Why this works

zw-knabbel-wp's bootstrap has used this exact pattern for a while and lints clean — no .stub needed. The .stub trick was over-engineered; this is the simpler shape.

## Test plan

- [ ] Lint (PHP 8.3, PHP 8.4) passes — phpstan still finds the constants, plugin-check accepts the guard.