### PR TITLE
refactor: tidy admin assets and audit status filter rendering

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -546,7 +546,7 @@ function animateText(element, text, button, warning = null) {
         if (index < text.length) {
             // Type multiple characters at once - faster
             const charsToType = Math.floor(Math.random() * 6) + 2; // 2-7 chars
-            const newText = text.substr(index, charsToType);
+            const newText = text.slice(index, index + charsToType);
             index += newText.length;
 
             element.value += newText;

--- a/assets/audit.css
+++ b/assets/audit.css
@@ -173,7 +173,3 @@
 .change-percentage.high-change {
     background: #dc3232;
 }
-
-.zw-audit-table .column-change .change-percentage {
-    display: inline-block;
-}

--- a/includes/AjaxSecurity.php
+++ b/includes/AjaxSecurity.php
@@ -59,7 +59,7 @@ trait AjaxSecurity {
 	 */
 	protected function validate_page_access( string $required_capability, string $error_message = '' ): void {
 		if ( ! current_user_can( $required_capability ) ) {
-			$message = $error_message ? $error_message : __( 'Je hebt geen toestemming om deze pagina te bekijken.', 'zw-ttvgpt' );
+			$message = ! empty( $error_message ) ? $error_message : __( 'Je hebt geen toestemming om deze pagina te bekijken.', 'zw-ttvgpt' );
 			wp_die( esc_html( $message ) );
 		}
 	}

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -164,9 +164,6 @@ class AuditPage {
 			'month' => $month,
 		);
 
-		$human_status = AuditStatus::FullyHumanWritten;
-		$ai_unedited  = AuditStatus::AiWrittenNotEdited;
-		$ai_edited    = AuditStatus::AiWrittenEdited;
 		?>
 		<h2 class="screen-reader-text"><?php esc_html_e( 'Auditlog filteren', 'zw-ttvgpt' ); ?></h2>
 		<ul class="subsubsub">
@@ -177,48 +174,22 @@ class AuditPage {
 					<?php esc_html_e( 'Alle', 'zw-ttvgpt' ); ?> <span class="count">(<?php echo esc_html( (string) $total ); ?>)</span>
 				</a>
 			</li>
-			<li class="<?php echo esc_attr( $human_status->get_css_class() ); ?>">
+			<?php foreach ( AuditStatus::cases() as $status ) : ?>
 				<?php
-				$human_params   = array_merge( $current_params, array( 'status' => $human_status->value ) );
-				$human_url      = add_query_arg( $human_params, $base_url );
-				$human_selected = $human_status->value === $status_filter;
+				$params   = array_merge( $current_params, array( 'status' => $status->value ) );
+				$url      = add_query_arg( $params, $base_url );
+				$selected = $status->value === $status_filter;
 				?>
-				<a href="<?php echo esc_url( $human_url ); ?>"
-					<?php if ( $human_selected ) : ?>
-					class="current" aria-current="page"
-					<?php endif; ?>>
-					<?php echo esc_html( $human_status->get_label() ); ?>
-					<span class="count">(<?php echo esc_html( (string) $counts[ $human_status->value ] ); ?>)</span>
-				</a>
-			</li>
-			<li class="<?php echo esc_attr( $ai_unedited->get_css_class() ); ?>">
-				<?php
-				$unedited_params   = array_merge( $current_params, array( 'status' => $ai_unedited->value ) );
-				$unedited_url      = add_query_arg( $unedited_params, $base_url );
-				$unedited_selected = $ai_unedited->value === $status_filter;
-				?>
-				<a href="<?php echo esc_url( $unedited_url ); ?>"
-					<?php if ( $unedited_selected ) : ?>
-					class="current" aria-current="page"
-					<?php endif; ?>>
-					<?php echo esc_html( $ai_unedited->get_label() ); ?>
-					<span class="count">(<?php echo esc_html( (string) $counts[ $ai_unedited->value ] ); ?>)</span>
-				</a>
-			</li>
-			<li class="<?php echo esc_attr( $ai_edited->get_css_class() ); ?>">
-				<?php
-				$edited_params   = array_merge( $current_params, array( 'status' => $ai_edited->value ) );
-				$edited_url      = add_query_arg( $edited_params, $base_url );
-				$edited_selected = $ai_edited->value === $status_filter;
-				?>
-				<a href="<?php echo esc_url( $edited_url ); ?>"
-					<?php if ( $edited_selected ) : ?>
-					class="current" aria-current="page"
-					<?php endif; ?>>
-					<?php echo esc_html( $ai_edited->get_label() ); ?>
-					<span class="count">(<?php echo esc_html( (string) $counts[ $ai_edited->value ] ); ?>)</span>
-				</a>
-			</li>
+				<li class="<?php echo esc_attr( $status->get_css_class() ); ?>">
+					<a href="<?php echo esc_url( $url ); ?>"
+						<?php if ( $selected ) : ?>
+						class="current" aria-current="page"
+						<?php endif; ?>>
+						<?php echo esc_html( $status->get_label() ); ?>
+						<span class="count">(<?php echo esc_html( (string) $counts[ $status->value ] ); ?>)</span>
+					</a>
+				</li>
+			<?php endforeach; ?>
 		</ul>
 		<?php
 	}

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -154,7 +154,7 @@ class AuditPage {
 	 * @param string $status_filter Current status filter value.
 	 * @param array  $counts        Statistics counts for each category.
 	 *
-	 * @phpstan-param array<string, int> $counts
+	 * @phpstan-param array<value-of<AuditStatus>, int> $counts
 	 */
 	private function render_status_links( int $year, int $month, string $status_filter, array $counts ): void {
 		$total          = array_sum( $counts );
@@ -208,7 +208,7 @@ class AuditPage {
 	 * @param string $which            Position of navigation ('top' or 'bottom').
 	 *
 	 * @phpstan-param array<int, MonthData> $available_months
-	 * @phpstan-param array<string, int> $counts
+	 * @phpstan-param array<value-of<AuditStatus>, int> $counts
 	 */
 	private function render_tablenav(
 		int $year,

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -186,7 +186,7 @@ class AuditPage {
 						class="current" aria-current="page"
 						<?php endif; ?>>
 						<?php echo esc_html( $status->get_label() ); ?>
-						<span class="count">(<?php echo esc_html( (string) $counts[ $status->value ] ); ?>)</span>
+						<span class="count">(<?php echo esc_html( (string) ( $counts[ $status->value ] ?? 0 ) ); ?>)</span>
 					</a>
 				</li>
 			<?php endforeach; ?>


### PR DESCRIPTION
## Summary

Four small cleanups bundled into one PR; no behavior change.

### Changes

- **`assets/audit.css`** — Remove redundant `.zw-audit-table .column-change .change-percentage { display: inline-block; }` rule. The base `.change-percentage` declaration earlier in the file already sets `display: inline-block`, so the more specific selector is a pure no-op override.
- **`assets/admin.js`** — Replace `String.prototype.substr()` (legacy, deprecated in favour of `.slice()` / `.substring()`) with `.slice(index, index + charsToType)` in the typing animation. Identical output for the positive arguments used here (2–7 characters).
- **`includes/AjaxSecurity.php`** — Use `! empty( \$error_message )` instead of a bare truthy check in `validate_page_access()` default-message handling, per WordPress Coding Standards preference. Semantically identical for the relevant input range (default `''` plus any falsy string).
- **`includes/admin/AuditPage.php`** — Fold three near-identical hardcoded `<li>` status-filter blocks (~40 lines) into a single `foreach ( AuditStatus::cases() as \$status )` loop. The enum already provides `get_label()` and `get_css_class()`; iterating over `::cases()` removes the per-status duplication. Rendered HTML is unchanged.

## Why bundled

Each item individually is too small for a focused PR (1–10 lines of net change). Splitting them would create four near-empty review threads with the same fixed overhead as one combined review. Scope is kept narrow: cleanups only, no behavior changes, no new abstractions.

## Test plan

- [ ] Audit page (Tools → Tekst TV Audit): status filter links render correctly for all three statuses; counts unchanged; "current" highlighting still works when a filter is active.
- [ ] Generate a summary: typing animation still functions correctly.
- [ ] Visit a page requiring a capability the current user lacks: receives the default Dutch error message (\`Je hebt geen toestemming…\`).
- [ ] `composer lint` + `npm run lint` pass (note: pre-existing Biome warning on `assets/admin.js:245` for unused `parseError` catch binding is unrelated to this PR).