### PR TITLE
chore: code review quick wins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.4']
+        php-version: ['8.3', '8.4']
     name: PHP ${{ matrix.php-version }}
     steps:
       - uses: actions/checkout@v5

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -242,7 +242,7 @@ async function handleGenerateClick(e) {
         let data;
         try {
             data = await response.json();
-        } catch (parseError) {
+        } catch {
             throw new Error(`Server error: ${response.status}`);
         }
 

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -98,31 +98,6 @@ class Helper {
 	}
 
 	/**
-	 * Creates a SQL WHERE clause for filtering posts by date range.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $start_date Optional. Start date in Y-m-d format. Default empty.
-	 * @param string $end_date   Optional. End date in Y-m-d format. Default empty.
-	 * @return string SQL WHERE clause or empty string if dates invalid.
-	 */
-	public static function build_date_filter_clause( string $start_date = '', string $end_date = '' ): string {
-		if ( empty( $start_date ) || empty( $end_date ) ) {
-			return '';
-		}
-
-		global $wpdb;
-		$start_date = sanitize_text_field( $start_date );
-		$end_date   = sanitize_text_field( $end_date );
-
-		return $wpdb->prepare(
-			'AND p.post_date >= %s AND p.post_date <= %s',
-			$start_date . ' 00:00:00',
-			$end_date . ' 23:59:59'
-		);
-	}
-
-	/**
 	 * Retrieves the version string for asset cache management.
 	 *
 	 * @since 1.0.0

--- a/zw-ttvgpt.php
+++ b/zw-ttvgpt.php
@@ -6,8 +6,8 @@
  * Version: 0.3.0
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl
- * License: GPL-2.0-or-later
- * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * License: GPL-3.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: zw-ttvgpt
  * Requires at least: 6.8
  * Requires PHP: 8.3
@@ -77,18 +77,15 @@ function zw_ttvgpt_activate(): void {
 			Constants::get_default_settings()
 		);
 	}
-
-	flush_rewrite_rules();
 }
 register_activation_hook( __FILE__, 'zw_ttvgpt_activate' );
 
 /**
- * Removes temporary data and flushes rewrite rules.
+ * Removes temporary data on deactivation.
  *
  * @since 1.0.0
  */
 function zw_ttvgpt_deactivate(): void {
 	Helper::cleanup_transients();
-	flush_rewrite_rules();
 }
 register_deactivation_hook( __FILE__, 'zw_ttvgpt_deactivate' );


### PR DESCRIPTION
## Summary

Low-risk cleanup batch from a full-plugin code review. Five independent issues bundled because each is a one-liner with no behavior change.

- **License sync** — plugin header said `GPL-2.0-or-later` while `LICENSE`, `composer.json` and `README` all declare GPL v3. Header is canonical for WordPress.org metadata, so aligned it to `GPL-3.0-or-later`.
- **Dead code** — `Helper::build_date_filter_clause()` was unreferenced anywhere in the codebase. Removed.
- **flush_rewrite_rules()** — called on activate/deactivate but the plugin registers no CPTs or rewrite rules. Removed.
- **Biome warning** — `catch (parseError)` in `admin.js` never used the binding. Switched to optional catch binding.
- **CI matrix** — `test.yml` only ran PHP 8.4, but `phpcs.xml.dist` targets 8.3-8.4 and docs claim both are covered. Added 8.3.

## Test plan

- [x] `vendor/bin/phpcs` — 17/17 clean
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `npm run lint` — no warnings
- [x] `vendor/bin/phpunit` — 18/18 pass
- [x] CI green on PR (PHPUnit will run on both 8.3 and 8.4 for the first time)