### PR TITLE
refactor: robustness fixes (rate limit, ACF, logging, empty responses)

### DIFF
--- a/includes/ApiHandler.php
+++ b/includes/ApiHandler.php
@@ -201,6 +201,39 @@ class ApiHandler {
 	}
 
 	/**
+	 * Builds a sanitized log context from an API response payload.
+	 *
+	 * Only metadata fields are surfaced. Generated text, the prompt, and any
+	 * auth material are deliberately excluded so error logs remain safe to
+	 * forward even when the global debug flag is off.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, mixed> $data     Decoded response payload.
+	 * @param string               $api_type Human-readable API label.
+	 * @return array<string, mixed> Safe context for Logger::error().
+	 */
+	private function build_safe_response_context( array $data, string $api_type ): array {
+		$context = array( 'api_type' => $api_type );
+
+		foreach ( array( 'id', 'model', 'status' ) as $key ) {
+			if ( isset( $data[ $key ] ) && ( is_string( $data[ $key ] ) || is_int( $data[ $key ] ) ) ) {
+				$context[ $key ] = $data[ $key ];
+			}
+		}
+
+		if ( isset( $data['choices'][0]['finish_reason'] ) && is_string( $data['choices'][0]['finish_reason'] ) ) {
+			$context['finish_reason'] = $data['choices'][0]['finish_reason'];
+		}
+
+		if ( isset( $data['usage'] ) && is_array( $data['usage'] ) ) {
+			$context['usage'] = $data['usage'];
+		}
+
+		return $context;
+	}
+
+	/**
 	 * Retrieves the generated summary from a Chat Completions API response.
 	 *
 	 * @since 1.0.0
@@ -212,19 +245,25 @@ class ApiHandler {
 	 */
 	private function extract_chat_completions_summary( array $data ): string|\WP_Error {
 		if ( ! isset( $data['choices'][0]['message']['content'] ) ) {
-			$this->logger->error( 'Invalid Chat Completions API response structure' );
+			$this->logger->error(
+				'Invalid Chat Completions API response structure',
+				$this->build_safe_response_context( $data, 'Chat Completions' )
+			);
 			return new \WP_Error(
 				'invalid_response',
-				__( 'Ongeldig antwoord van de API', 'zw-ttvgpt' )
+				__( 'Ongeldig antwoord van de API. Probeer het opnieuw; raadpleeg bij herhaling de beheerder of debuglog.', 'zw-ttvgpt' )
 			);
 		}
 
 		$summary = trim( (string) $data['choices'][0]['message']['content'] );
 		if ( '' === $summary ) {
-			$this->logger->error( 'Empty Chat Completions API response' );
+			$this->logger->error(
+				'Empty Chat Completions API response',
+				$this->build_safe_response_context( $data, 'Chat Completions' )
+			);
 			return new \WP_Error(
 				'empty_response',
-				__( 'Lege samenvatting ontvangen van de API', 'zw-ttvgpt' )
+				__( 'Lege samenvatting ontvangen van de API. Probeer het opnieuw of kies een ander model in de instellingen.', 'zw-ttvgpt' )
 			);
 		}
 
@@ -266,18 +305,24 @@ class ApiHandler {
 		}
 
 		if ( null === $summary ) {
-			$this->logger->error( 'Invalid Responses API response structure' );
+			$this->logger->error(
+				'Invalid Responses API response structure',
+				$this->build_safe_response_context( $data, 'Responses' )
+			);
 			return new \WP_Error(
 				'invalid_response',
-				__( 'Ongeldig antwoord van de API', 'zw-ttvgpt' )
+				__( 'Ongeldig antwoord van de API. Probeer het opnieuw; raadpleeg bij herhaling de beheerder of debuglog.', 'zw-ttvgpt' )
 			);
 		}
 
 		if ( '' === $summary ) {
-			$this->logger->error( 'Empty Responses API response' );
+			$this->logger->error(
+				'Empty Responses API response',
+				$this->build_safe_response_context( $data, 'Responses' )
+			);
 			return new \WP_Error(
 				'empty_response',
-				__( 'Lege samenvatting ontvangen van de API', 'zw-ttvgpt' )
+				__( 'Lege samenvatting ontvangen van de API. Probeer het opnieuw of kies een ander model in de instellingen.', 'zw-ttvgpt' )
 			);
 		}
 

--- a/includes/ApiHandler.php
+++ b/includes/ApiHandler.php
@@ -214,7 +214,12 @@ class ApiHandler {
 	 * @return array<string, mixed> Safe context for Logger::error().
 	 */
 	private function build_safe_response_context( array $data, string $api_type ): array {
-		$context = array( 'api_type' => $api_type );
+		// Seed with what we know locally so malformed responses (which often lack a `model` field)
+		// still log the model we asked for — the most useful field when diagnosing rejections.
+		$context = array(
+			'api_type' => $api_type,
+			'model'    => $this->model,
+		);
 
 		foreach ( array( 'id', 'model', 'status' ) as $key ) {
 			if ( isset( $data[ $key ] ) && ( is_string( $data[ $key ] ) || is_int( $data[ $key ] ) ) ) {

--- a/includes/ApiHandler.php
+++ b/includes/ApiHandler.php
@@ -219,7 +219,16 @@ class ApiHandler {
 			);
 		}
 
-		return trim( (string) $data['choices'][0]['message']['content'] );
+		$summary = trim( (string) $data['choices'][0]['message']['content'] );
+		if ( '' === $summary ) {
+			$this->logger->error( 'Empty Chat Completions API response' );
+			return new \WP_Error(
+				'empty_response',
+				__( 'Lege samenvatting ontvangen van de API', 'zw-ttvgpt' )
+			);
+		}
+
+		return $summary;
 	}
 
 	/**
@@ -233,34 +242,46 @@ class ApiHandler {
 	 * @phpstan-param array<string, mixed> $data
 	 */
 	private function extract_responses_summary( array $data ): string|\WP_Error {
+		$summary = null;
+
 		// Check if output_text helper is available.
 		if ( isset( $data['output_text'] ) && is_string( $data['output_text'] ) ) {
-			return trim( $data['output_text'] );
-		}
-
-		// Parse output array to find message items.
-		if ( isset( $data['output'] ) && is_array( $data['output'] ) ) {
+			$summary = trim( $data['output_text'] );
+		} elseif ( isset( $data['output'] ) && is_array( $data['output'] ) ) {
+			// Parse output array to find message items.
 			foreach ( $data['output'] as $item ) {
 				if ( ! isset( $item['type'] ) ) {
 					continue;
 				}
 
-				// Look for message items.
 				if ( 'message' === $item['type'] && isset( $item['content'] ) && is_array( $item['content'] ) ) {
 					foreach ( $item['content'] as $content_item ) {
 						if ( isset( $content_item['type'] ) && 'output_text' === $content_item['type'] && isset( $content_item['text'] ) ) {
-							return trim( (string) $content_item['text'] );
+							$summary = trim( (string) $content_item['text'] );
+							break 2;
 						}
 					}
 				}
 			}
 		}
 
-		$this->logger->error( 'Invalid Responses API response structure' );
-		return new \WP_Error(
-			'invalid_response',
-			__( 'Ongeldig antwoord van de API', 'zw-ttvgpt' )
-		);
+		if ( null === $summary ) {
+			$this->logger->error( 'Invalid Responses API response structure' );
+			return new \WP_Error(
+				'invalid_response',
+				__( 'Ongeldig antwoord van de API', 'zw-ttvgpt' )
+			);
+		}
+
+		if ( '' === $summary ) {
+			$this->logger->error( 'Empty Responses API response' );
+			return new \WP_Error(
+				'empty_response',
+				__( 'Lege samenvatting ontvangen van de API', 'zw-ttvgpt' )
+			);
+		}
+
+		return $summary;
 	}
 
 	/**

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -67,7 +67,7 @@ class Logger {
 	 * @phpstan-param LogContext $context
 	 */
 	public function error( string $message, array $context = array() ): void {
-		$this->write_log( 'ERROR', $message, $this->debug_mode ? $context : array() );
+		$this->write_log( 'ERROR', $message, $context );
 	}
 
 

--- a/includes/RateLimiter.php
+++ b/includes/RateLimiter.php
@@ -22,24 +22,43 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class RateLimiter {
 	/**
-	 * Records a request and reports whether the user has now exceeded the limit.
+	 * Records a request and reports whether the user is now over the limit.
 	 *
-	 * Increments first, then compares — collapses the previous two-step
-	 * check-then-increment into a single read/write cycle, shrinking (but not
-	 * eliminating) the race window where parallel requests can both pass.
+	 * Note: `get_transient`/`set_transient` is not atomic, so concurrent requests
+	 * can race and both observe a pre-increment value. For stricter guarantees,
+	 * an object-cache-backed atomic counter would be required.
+	 *
+	 * Blocked requests deliberately do NOT refresh the transient: once a user
+	 * is over the cap, further attempts must not extend their own lockout window.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int $user_id User ID to check and record a request for.
+	 * @param int    $user_id User ID to check and record a request for.
+	 * @param Logger $logger  Logger for surfacing transient-write failures.
 	 * @return bool True if the user is now rate limited, false otherwise.
 	 */
-	public static function check_and_increment( int $user_id ): bool {
+	public static function check_and_increment( int $user_id, Logger $logger ): bool {
 		$transient_key = Constants::get_rate_limit_key( $user_id );
-		$requests      = get_transient( $transient_key );
+		$stored        = get_transient( $transient_key );
+		$current       = is_numeric( $stored ) ? (int) $stored : 0;
 
-		$count = is_numeric( $requests ) ? (int) $requests + 1 : 1;
-		set_transient( $transient_key, $count, Constants::RATE_LIMIT_WINDOW );
+		if ( $current >= Constants::RATE_LIMIT_MAX_REQUESTS ) {
+			return true;
+		}
 
-		return $count > Constants::RATE_LIMIT_MAX_REQUESTS;
+		$next  = $current + 1;
+		$saved = set_transient( $transient_key, $next, Constants::RATE_LIMIT_WINDOW );
+
+		if ( false === $saved ) {
+			$logger->error(
+				'Failed to persist rate-limit transient; rate limiting may be ineffective',
+				array(
+					'user_id' => $user_id,
+					'count'   => $next,
+				)
+			);
+		}
+
+		return false;
 	}
 }

--- a/includes/RateLimiter.php
+++ b/includes/RateLimiter.php
@@ -22,41 +22,24 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class RateLimiter {
 	/**
-	 * Determines whether a user is currently rate limited.
+	 * Records a request and reports whether the user has now exceeded the limit.
+	 *
+	 * Increments first, then compares — collapses the previous two-step
+	 * check-then-increment into a single read/write cycle, shrinking (but not
+	 * eliminating) the race window where parallel requests can both pass.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int $user_id User ID to check rate limit for.
-	 * @return bool True if user is rate limited, false otherwise.
+	 * @param int $user_id User ID to check and record a request for.
+	 * @return bool True if the user is now rate limited, false otherwise.
 	 */
-	public static function is_limited( int $user_id ): bool {
+	public static function check_and_increment( int $user_id ): bool {
 		$transient_key = Constants::get_rate_limit_key( $user_id );
 		$requests      = get_transient( $transient_key );
 
-		// false = transient not set, int = request count.
-		if ( false === $requests ) {
-			return false;
-		}
+		$count = is_numeric( $requests ) ? (int) $requests + 1 : 1;
+		set_transient( $transient_key, $count, Constants::RATE_LIMIT_WINDOW );
 
-		return (int) $requests >= Constants::RATE_LIMIT_MAX_REQUESTS;
-	}
-
-	/**
-	 * Records an API request for rate limiting purposes.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param int $user_id User ID to record request for.
-	 * @return void
-	 */
-	public static function increment( int $user_id ): void {
-		$transient_key = Constants::get_rate_limit_key( $user_id );
-		$requests      = get_transient( $transient_key );
-
-		if ( false === $requests ) {
-			set_transient( $transient_key, 1, Constants::RATE_LIMIT_WINDOW );
-		} else {
-			set_transient( $transient_key, $requests + 1, Constants::RATE_LIMIT_WINDOW );
-		}
+		return $count > Constants::RATE_LIMIT_MAX_REQUESTS;
 	}
 }

--- a/includes/SummaryGenerator.php
+++ b/includes/SummaryGenerator.php
@@ -89,11 +89,23 @@ class SummaryGenerator {
 		}
 
 		$user_id = get_current_user_id();
-		if ( RateLimiter::check_and_increment( $user_id ) ) {
+		if ( RateLimiter::check_and_increment( $user_id, $this->logger ) ) {
 			AjaxResponse::error(
 				'rate_limited',
 				__( 'Wacht even - max 10 per minuut', 'zw-ttvgpt' ),
 				429
+			);
+		}
+
+		// Bail before the paid API call when ACF is unavailable: save_to_acf()
+		// would otherwise fail post-generation, wasting tokens for a result we
+		// cannot persist.
+		if ( ! function_exists( 'update_field' ) ) {
+			$this->logger->error( 'ACF unavailable - aborting before API call', array( 'post_id' => $post_id ) );
+			AjaxResponse::error(
+				'acf_unavailable',
+				__( 'Advanced Custom Fields is niet actief. Activeer ACF voordat je samenvattingen genereert.', 'zw-ttvgpt' ),
+				503
 			);
 		}
 

--- a/includes/SummaryGenerator.php
+++ b/includes/SummaryGenerator.php
@@ -89,7 +89,7 @@ class SummaryGenerator {
 		}
 
 		$user_id = get_current_user_id();
-		if ( RateLimiter::is_limited( $user_id ) ) {
+		if ( RateLimiter::check_and_increment( $user_id ) ) {
 			AjaxResponse::error(
 				'rate_limited',
 				__( 'Wacht even - max 10 per minuut', 'zw-ttvgpt' ),
@@ -124,7 +124,6 @@ class SummaryGenerator {
 			);
 		}
 
-		RateLimiter::increment( $user_id );
 		$this->logger->debug( 'Summary generated for post ' . $post_id );
 
 		$response = array(

--- a/includes/admin/SettingsPage.php
+++ b/includes/admin/SettingsPage.php
@@ -510,7 +510,12 @@ class SettingsPage {
 		// Debug mode.
 		$sanitized['debug_mode'] = ! empty( $input['debug_mode'] );
 
-		$this->logger->debug( 'Settings updated', $sanitized );
+		// Redact api_key before logging; debug.log can be world-readable depending on host config.
+		$loggable = $sanitized;
+		if ( array_key_exists( 'api_key', $loggable ) ) {
+			$loggable['api_key'] = '' === $loggable['api_key'] ? '' : '[redacted]';
+		}
+		$this->logger->debug( 'Settings updated', $loggable );
 		SettingsManager::clear_cache();
 
 		return $sanitized;

--- a/tests/ApiHandlerExtractTest.php
+++ b/tests/ApiHandlerExtractTest.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use WP_Error;
+use ZW_TTVGPT_Core\ApiHandler;
+
+#[CoversClass(ApiHandler::class)]
+final class ApiHandlerExtractTest extends TestCase {
+
+	private RecordingLogger $logger;
+	private ApiHandler $handler;
+
+	protected function setUp(): void {
+		$this->logger  = new RecordingLogger();
+		$this->handler = new ApiHandler( 'sk-test', 'gpt-5.5', $this->logger );
+	}
+
+	/**
+	 * @param array<string, mixed> $data
+	 */
+	private function invoke_chat( array $data ): string|WP_Error {
+		$method = new ReflectionMethod( ApiHandler::class, 'extract_chat_completions_summary' );
+		/** @var string|WP_Error $result */
+		$result = $method->invoke( $this->handler, $data );
+		return $result;
+	}
+
+	/**
+	 * @param array<string, mixed> $data
+	 */
+	private function invoke_responses( array $data ): string|WP_Error {
+		$method = new ReflectionMethod( ApiHandler::class, 'extract_responses_summary' );
+		/** @var string|WP_Error $result */
+		$result = $method->invoke( $this->handler, $data );
+		return $result;
+	}
+
+	public function test_chat_valid_response_returns_trimmed_summary(): void {
+		$result = $this->invoke_chat(
+			array(
+				'choices' => array(
+					array( 'message' => array( 'content' => "  hello world  \n" ) ),
+				),
+			)
+		);
+
+		self::assertSame( 'hello world', $result );
+		self::assertSame( array(), $this->logger->errors );
+	}
+
+	public function test_chat_empty_content_returns_empty_response_error_with_safe_context(): void {
+		$result = $this->invoke_chat(
+			array(
+				'id'      => 'chatcmpl-x',
+				'model'   => 'gpt-4.1-mini',
+				'usage'   => array( 'total_tokens' => 1 ),
+				'choices' => array(
+					array(
+						'message'       => array( 'content' => '   ' ),
+						'finish_reason' => 'length',
+					),
+				),
+			)
+		);
+
+		self::assertInstanceOf( WP_Error::class, $result );
+		self::assertSame( 'empty_response', $result->get_error_code() );
+
+		self::assertCount( 1, $this->logger->errors );
+		$context = $this->logger->errors[0]['context'];
+		self::assertSame( 'Chat Completions', $context['api_type'] );
+		self::assertSame( 'gpt-4.1-mini', $context['model'] );
+		self::assertSame( 'chatcmpl-x', $context['id'] );
+		self::assertSame( 'length', $context['finish_reason'] );
+		self::assertSame( array( 'total_tokens' => 1 ), $context['usage'] );
+		self::assertArrayNotHasKey( 'content', $context );
+		self::assertArrayNotHasKey( 'choices', $context );
+	}
+
+	public function test_chat_missing_structure_returns_invalid_response_error(): void {
+		$result = $this->invoke_chat( array( 'id' => 'chatcmpl-y' ) );
+
+		self::assertInstanceOf( WP_Error::class, $result );
+		self::assertSame( 'invalid_response', $result->get_error_code() );
+		self::assertCount( 1, $this->logger->errors );
+		self::assertSame( 'chatcmpl-y', $this->logger->errors[0]['context']['id'] );
+	}
+
+	public function test_responses_output_text_helper_returns_trimmed_summary(): void {
+		$result = $this->invoke_responses( array( 'output_text' => '  summary  ' ) );
+
+		self::assertSame( 'summary', $result );
+		self::assertSame( array(), $this->logger->errors );
+	}
+
+	public function test_responses_output_array_walk_finds_text_and_stops(): void {
+		$result = $this->invoke_responses(
+			array(
+				'output' => array(
+					array( 'type' => 'reasoning' ),
+					array(
+						'type'    => 'message',
+						'content' => array(
+							array(
+								'type' => 'output_text',
+								'text' => 'walked text',
+							),
+							array(
+								'type' => 'output_text',
+								'text' => 'should be ignored',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		self::assertSame( 'walked text', $result );
+	}
+
+	public function test_responses_empty_text_returns_empty_response_error(): void {
+		$result = $this->invoke_responses(
+			array(
+				'id'     => 'resp_x',
+				'model'  => 'gpt-5.5',
+				'status' => 'completed',
+				'output' => array(
+					array(
+						'type'    => 'message',
+						'content' => array(
+							array(
+								'type' => 'output_text',
+								'text' => '   ',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		self::assertInstanceOf( WP_Error::class, $result );
+		self::assertSame( 'empty_response', $result->get_error_code() );
+
+		self::assertCount( 1, $this->logger->errors );
+		$context = $this->logger->errors[0]['context'];
+		self::assertSame( 'Responses', $context['api_type'] );
+		self::assertSame( 'gpt-5.5', $context['model'] );
+		self::assertSame( 'completed', $context['status'] );
+	}
+
+	public function test_responses_missing_structure_returns_invalid_response_error(): void {
+		$result = $this->invoke_responses( array() );
+
+		self::assertInstanceOf( WP_Error::class, $result );
+		self::assertSame( 'invalid_response', $result->get_error_code() );
+	}
+
+	public function test_responses_output_without_message_items_returns_invalid_response_error(): void {
+		$result = $this->invoke_responses(
+			array(
+				'output' => array(
+					array( 'type' => 'reasoning' ),
+				),
+			)
+		);
+
+		self::assertInstanceOf( WP_Error::class, $result );
+		self::assertSame( 'invalid_response', $result->get_error_code() );
+	}
+}

--- a/tests/ApiHandlerExtractTest.php
+++ b/tests/ApiHandlerExtractTest.php
@@ -88,7 +88,11 @@ final class ApiHandlerExtractTest extends TestCase {
 		self::assertInstanceOf( WP_Error::class, $result );
 		self::assertSame( 'invalid_response', $result->get_error_code() );
 		self::assertCount( 1, $this->logger->errors );
-		self::assertSame( 'chatcmpl-y', $this->logger->errors[0]['context']['id'] );
+
+		$context = $this->logger->errors[0]['context'];
+		self::assertSame( 'chatcmpl-y', $context['id'] );
+		// Configured model must survive into the log even when the response payload omits it.
+		self::assertSame( 'gpt-5.5', $context['model'] );
 	}
 
 	public function test_responses_output_text_helper_returns_trimmed_summary(): void {
@@ -158,6 +162,12 @@ final class ApiHandlerExtractTest extends TestCase {
 
 		self::assertInstanceOf( WP_Error::class, $result );
 		self::assertSame( 'invalid_response', $result->get_error_code() );
+
+		self::assertCount( 1, $this->logger->errors );
+		$context = $this->logger->errors[0]['context'];
+		self::assertSame( 'Responses', $context['api_type'] );
+		// Configured model must survive into the log even when the response payload omits it.
+		self::assertSame( 'gpt-5.5', $context['model'] );
 	}
 
 	public function test_responses_output_without_message_items_returns_invalid_response_error(): void {

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZW_TTVGPT_Core\Constants;
+use ZW_TTVGPT_Core\RateLimiter;
+
+#[CoversClass(RateLimiter::class)]
+final class RateLimiterTest extends TestCase {
+
+	private const int USER_ID = 7;
+
+	private RecordingLogger $logger;
+
+	protected function setUp(): void {
+		$GLOBALS['zw_test_transients']           = array();
+		$GLOBALS['zw_test_set_transient_return'] = true;
+		$GLOBALS['zw_test_set_transient_calls']  = array();
+		$this->logger                            = new RecordingLogger();
+	}
+
+	public function test_first_request_returns_false_and_persists_count_one_with_window_ttl(): void {
+		self::assertFalse( RateLimiter::check_and_increment( self::USER_ID, $this->logger ) );
+
+		$key = Constants::get_rate_limit_key( self::USER_ID );
+		self::assertSame( 1, $GLOBALS['zw_test_transients'][ $key ] );
+		self::assertCount( 1, $GLOBALS['zw_test_set_transient_calls'] );
+		self::assertSame( Constants::RATE_LIMIT_WINDOW, $GLOBALS['zw_test_set_transient_calls'][0]['expiration'] );
+	}
+
+	public function test_last_request_under_cap_still_succeeds(): void {
+		$key                                   = Constants::get_rate_limit_key( self::USER_ID );
+		$GLOBALS['zw_test_transients'][ $key ] = Constants::RATE_LIMIT_MAX_REQUESTS - 1;
+
+		self::assertFalse( RateLimiter::check_and_increment( self::USER_ID, $this->logger ) );
+		self::assertSame( Constants::RATE_LIMIT_MAX_REQUESTS, $GLOBALS['zw_test_transients'][ $key ] );
+	}
+
+	public function test_request_at_cap_is_rate_limited(): void {
+		$key                                   = Constants::get_rate_limit_key( self::USER_ID );
+		$GLOBALS['zw_test_transients'][ $key ] = Constants::RATE_LIMIT_MAX_REQUESTS;
+
+		self::assertTrue( RateLimiter::check_and_increment( self::USER_ID, $this->logger ) );
+	}
+
+	/**
+	 * Regression: blocked requests must not slide the lockout window forward.
+	 *
+	 * Prior implementation called set_transient() on every invocation, which on
+	 * most cache backends refreshes the TTL — letting a spam-clicking user
+	 * indefinitely extend their own 60-second lockout.
+	 */
+	public function test_blocked_request_does_not_refresh_transient(): void {
+		$key                                   = Constants::get_rate_limit_key( self::USER_ID );
+		$GLOBALS['zw_test_transients'][ $key ] = Constants::RATE_LIMIT_MAX_REQUESTS;
+
+		RateLimiter::check_and_increment( self::USER_ID, $this->logger );
+
+		self::assertSame( array(), $GLOBALS['zw_test_set_transient_calls'] );
+	}
+
+	public function test_request_far_above_cap_remains_blocked_without_refresh(): void {
+		$key                                   = Constants::get_rate_limit_key( self::USER_ID );
+		$GLOBALS['zw_test_transients'][ $key ] = Constants::RATE_LIMIT_MAX_REQUESTS + 5;
+
+		self::assertTrue( RateLimiter::check_and_increment( self::USER_ID, $this->logger ) );
+		self::assertSame( array(), $GLOBALS['zw_test_set_transient_calls'] );
+	}
+
+	public function test_non_numeric_stored_value_resets_to_one(): void {
+		$key                                   = Constants::get_rate_limit_key( self::USER_ID );
+		$GLOBALS['zw_test_transients'][ $key ] = 'corrupted';
+
+		self::assertFalse( RateLimiter::check_and_increment( self::USER_ID, $this->logger ) );
+		self::assertSame( 1, $GLOBALS['zw_test_transients'][ $key ] );
+	}
+
+	public function test_set_transient_failure_is_logged(): void {
+		$GLOBALS['zw_test_set_transient_return'] = false;
+
+		self::assertFalse( RateLimiter::check_and_increment( self::USER_ID, $this->logger ) );
+
+		self::assertCount( 1, $this->logger->errors );
+		self::assertStringContainsString( 'Failed to persist rate-limit transient', $this->logger->errors[0]['message'] );
+		self::assertSame( self::USER_ID, $this->logger->errors[0]['context']['user_id'] );
+		self::assertSame( 1, $this->logger->errors[0]['context']['count'] );
+	}
+
+	public function test_successful_set_transient_does_not_log_error(): void {
+		RateLimiter::check_and_increment( self::USER_ID, $this->logger );
+
+		self::assertSame( array(), $this->logger->errors );
+	}
+}

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -39,26 +39,16 @@ final class RateLimiterTest extends TestCase {
 		self::assertSame( Constants::RATE_LIMIT_MAX_REQUESTS, $GLOBALS['zw_test_transients'][ $key ] );
 	}
 
-	public function test_request_at_cap_is_rate_limited(): void {
+	/**
+	 * Regression: at the cap the call must return true *and* must not write,
+	 * because writing refreshes the transient TTL on most cache backends and
+	 * lets a spam-clicking user indefinitely extend their own 60-second lockout.
+	 */
+	public function test_request_at_cap_returns_true_without_refreshing_transient(): void {
 		$key                                   = Constants::get_rate_limit_key( self::USER_ID );
 		$GLOBALS['zw_test_transients'][ $key ] = Constants::RATE_LIMIT_MAX_REQUESTS;
 
 		self::assertTrue( RateLimiter::check_and_increment( self::USER_ID, $this->logger ) );
-	}
-
-	/**
-	 * Regression: blocked requests must not slide the lockout window forward.
-	 *
-	 * Prior implementation called set_transient() on every invocation, which on
-	 * most cache backends refreshes the TTL — letting a spam-clicking user
-	 * indefinitely extend their own 60-second lockout.
-	 */
-	public function test_blocked_request_does_not_refresh_transient(): void {
-		$key                                   = Constants::get_rate_limit_key( self::USER_ID );
-		$GLOBALS['zw_test_transients'][ $key ] = Constants::RATE_LIMIT_MAX_REQUESTS;
-
-		RateLimiter::check_and_increment( self::USER_ID, $this->logger );
-
 		self::assertSame( array(), $GLOBALS['zw_test_set_transient_calls'] );
 	}
 

--- a/tests/RecordingLogger.php
+++ b/tests/RecordingLogger.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use ZW_TTVGPT_Core\Logger;
+
+/**
+ * Test double that records error/debug calls instead of writing to error_log.
+ *
+ * Lets tests assert on logger interactions without depending on WP's logging
+ * stack or the global error_log destination.
+ */
+final class RecordingLogger extends Logger {
+	/** @var list<array{message: string, context: array<string, mixed>}> */
+	public array $errors = array();
+
+	/** @var list<array{message: string, context: array<string, mixed>}> */
+	public array $debugs = array();
+
+	public function __construct() {
+		parent::__construct( false );
+	}
+
+	public function error( string $message, array $context = array() ): void {
+		$this->errors[] = array(
+			'message' => $message,
+			'context' => $context,
+		);
+	}
+
+	public function debug( string $message, array $context = array() ): void {
+		$this->debugs[] = array(
+			'message' => $message,
+			'context' => $context,
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,3 +6,65 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/RecordingLogger.php';
+
+// In-memory transient store used by tests that exercise the rate limiter.
+$GLOBALS['zw_test_transients']            = array();
+$GLOBALS['zw_test_set_transient_return']  = true;
+$GLOBALS['zw_test_set_transient_calls']   = array();
+
+if ( ! function_exists( 'get_transient' ) ) {
+	/**
+	 * @return mixed
+	 */
+	function get_transient( string $key ) {
+		return $GLOBALS['zw_test_transients'][ $key ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( string $key, mixed $value, int $expiration = 0 ): bool {
+		$GLOBALS['zw_test_set_transient_calls'][] = array(
+			'key'        => $key,
+			'value'      => $value,
+			'expiration' => $expiration,
+		);
+		if ( false === $GLOBALS['zw_test_set_transient_return'] ) {
+			return false;
+		}
+		$GLOBALS['zw_test_transients'][ $key ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		return $text;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		private string $code;
+		private string $message;
+		private mixed $data;
+
+		public function __construct( string $code = '', string $message = '', mixed $data = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		public function get_error_data(): mixed {
+			return $this->data;
+		}
+	}
+}

--- a/zw-ttvgpt.php
+++ b/zw-ttvgpt.php
@@ -77,10 +77,6 @@ add_action( 'init', 'zw_ttvgpt_init' );
  * @since 1.0.0
  */
 function zw_ttvgpt_acf_dependency_notice(): void {
-	if ( wp_doing_ajax() ) {
-		return;
-	}
-
 	if ( function_exists( 'update_field' ) ) {
 		return;
 	}

--- a/zw-ttvgpt.php
+++ b/zw-ttvgpt.php
@@ -11,6 +11,7 @@
  * Text Domain: zw-ttvgpt
  * Requires at least: 6.8
  * Requires PHP: 8.3
+ * Requires Plugins: advanced-custom-fields
  *
  * @package ZW_TTVGPT
  * @since   1.0.0
@@ -64,6 +65,32 @@ function zw_ttvgpt_init(): void {
 	}
 }
 add_action( 'init', 'zw_ttvgpt_init' );
+
+/**
+ * Surfaces a persistent admin notice when ACF is not active.
+ *
+ * The `Requires Plugins` header gates new installs on WP 6.5+, but existing
+ * users who deactivate ACF would otherwise only see a save-time error.
+ *
+ * @since 1.0.0
+ */
+function zw_ttvgpt_acf_dependency_notice(): void {
+	if ( function_exists( 'update_field' ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'activate_plugins' ) ) {
+		return;
+	}
+
+	echo '<div class="notice notice-error"><p>';
+	echo esc_html__(
+		'ZuidWest Tekst TV GPT vereist de Advanced Custom Fields plugin. Activeer ACF om samenvattingen te kunnen genereren.',
+		'zw-ttvgpt'
+	);
+	echo '</p></div>';
+}
+add_action( 'admin_notices', 'zw_ttvgpt_acf_dependency_notice' );
 
 /**
  * Validates environment and initializes plugin settings on activation.

--- a/zw-ttvgpt.php
+++ b/zw-ttvgpt.php
@@ -69,12 +69,18 @@ add_action( 'init', 'zw_ttvgpt_init' );
 /**
  * Surfaces a persistent admin notice when ACF is not active.
  *
- * The `Requires Plugins` header gates new installs on WP 6.5+, but existing
- * users who deactivate ACF would otherwise only see a save-time error.
+ * Without ACF the AJAX handler short-circuits with an `acf_unavailable` error
+ * (see SummaryGenerator::handle_ajax_request). This notice surfaces the same
+ * condition up front so admins can fix the dependency before users try to
+ * generate summaries, instead of finding out via a failed AJAX response.
  *
  * @since 1.0.0
  */
 function zw_ttvgpt_acf_dependency_notice(): void {
+	if ( wp_doing_ajax() ) {
+		return;
+	}
+
 	if ( function_exists( 'update_field' ) ) {
 		return;
 	}


### PR DESCRIPTION
## Summary

Second batch from the full-plugin code review. Follows #154 (quick wins, already merged).

- **RateLimiter** — \`is_limited\` + \`increment\` was a two-step read/write where parallel requests could both pass the check before either incremented. Merged into one \`check_and_increment\` that bumps first and compares, shrinking the race window to a single cycle.
- **ACF dependency** — added the WP 6.5+ \`Requires Plugins: advanced-custom-fields\` header so new installs are gated, plus an \`admin_notices\` callback so existing installs that deactivate ACF get a clear warning instead of only the save-time error.
- **Logger** — \`error()\` was silently dropping context outside debug mode. Production logs now keep status codes / post IDs / model names so issues are actually diagnosable in the wild.
- **ApiHandler** — both extract methods (Chat Completions and Responses) could return an empty string after \`trim()\`, which the retry loop would exhaust and surface to the user as a blank summary with a generic warning. Now returns \`WP_Error('empty_response')\` with a Dutch user-facing message so the failure mode is visible.

### Note on behavior change

Failed API calls now count against the user's rate limit (previously the counter only bumped on successful save). This is intentional: it prevents endless retry storms against a broken endpoint. The pre-flight \`missing_config\` / \`invalid_input\` paths still exit before the rate-limit check, so misconfiguration doesn't burn slots.

## Test plan

- [x] \`vendor/bin/phpcs\` — clean
- [x] \`vendor/bin/phpstan analyse\` — clean
- [x] \`npm run lint\` — clean
- [x] \`vendor/bin/phpunit\` — 18/18
- [ ] Manual: trigger an empty OpenAI response and confirm the user sees the new error
- [ ] Manual: deactivate ACF and confirm the admin notice appears
- [ ] Manual: hammer the AJAX endpoint and confirm the rate limit trips at the 11th request