### PR TITLE
perf: scale audit page and trim transient cleanup

### DIFF
--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -185,66 +185,24 @@ class AuditHelper {
 
 
 	/**
-	 * Retrieves metadata for multiple posts in a single query.
+	 * Primes WordPress' meta cache for a set of posts.
+	 *
+	 * Subsequent get_post_meta() calls on these posts hit the cache without
+	 * extra queries. Replaces a hand-rolled OR-query that bypassed the cache
+	 * and didn't scale on large months.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param array $post_ids Array of post IDs.
-	 * @return array Associative array with post_id as key and meta_data as value.
 	 *
 	 * @phpstan-param array<int, int> $post_ids
-	 * @phpstan-return array<int, array<string, string>>
 	 */
-	public static function get_bulk_meta_data( array $post_ids ): array {
+	public static function prime_meta_cache( array $post_ids ): void {
 		if ( empty( $post_ids ) ) {
-			return array();
+			return;
 		}
 
-		global $wpdb;
-
-		// Sanitize post IDs to integers only.
-		$post_ids = array_map( 'intval', $post_ids );
-
-		// Single query to get all meta data for all posts.
-		$meta_keys = array(
-			Constants::ACF_FIELD_AI_CONTENT,
-			Constants::ACF_FIELD_HUMAN_CONTENT,
-			'_edit_last',
-		);
-
-		// Build WHERE clause for post IDs.
-		$where_post_ids = array();
-		foreach ( $post_ids as $id ) {
-			$where_post_ids[] = $wpdb->prepare( 'post_id = %d', $id );
-		}
-
-		// Build WHERE clause for meta keys.
-		$where_meta_keys = array();
-		foreach ( $meta_keys as $key ) {
-			$where_meta_keys[] = $wpdb->prepare( 'meta_key = %s', $key );
-		}
-
-		// Combine conditions.
-		$where_post_clause = '(' . implode( ' OR ', $where_post_ids ) . ')';
-		$where_key_clause  = '(' . implode( ' OR ', $where_meta_keys ) . ')';
-
-		// Build final query.
-		$query = "SELECT post_id, meta_key, meta_value 
-			FROM {$wpdb->postmeta} 
-			WHERE {$where_post_clause}
-			AND {$where_key_clause}
-			ORDER BY post_id";
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is built from individually prepared fragments above
-		$meta_data = $wpdb->get_results( $query );
-
-		// Organize data by post_id for fast lookup.
-		$meta_cache = array();
-		foreach ( $meta_data as $meta ) {
-			$meta_cache[ $meta->post_id ][ $meta->meta_key ] = $meta->meta_value;
-		}
-
-		return $meta_cache;
+		update_meta_cache( 'post', array_map( 'intval', $post_ids ) );
 	}
 
 	/**
@@ -265,20 +223,19 @@ class AuditHelper {
 	/**
 	 * Determines the audit status of a post.
 	 *
+	 * Callers should prime the meta cache with prime_meta_cache() before
+	 * looping over many posts so get_post_meta hits the cache.
+	 *
 	 * @since 1.0.0
 	 *
-	 * @param \WP_Post $post       Post object to categorize.
-	 * @param array    $meta_cache Optional. Pre-fetched meta data cache. Default empty array.
+	 * @param \WP_Post $post Post object to categorize.
 	 * @return array Analysis result with status (AuditStatus enum), ai_content, human_content, and change_percentage.
 	 *
-	 * @phpstan-param array<int, array<string, string>> $meta_cache
 	 * @phpstan-return PostAnalysis
 	 */
-	public static function categorize_post( \WP_Post $post, array $meta_cache = array() ): array {
-		$ai_key        = Constants::ACF_FIELD_AI_CONTENT;
-		$human_key     = Constants::ACF_FIELD_HUMAN_CONTENT;
-		$ai_content    = $meta_cache[ $post->ID ][ $ai_key ] ?? get_post_meta( $post->ID, $ai_key, true );
-		$human_content = $meta_cache[ $post->ID ][ $human_key ] ?? get_post_meta( $post->ID, $human_key, true );
+	public static function categorize_post( \WP_Post $post ): array {
+		$ai_content    = (string) get_post_meta( $post->ID, Constants::ACF_FIELD_AI_CONTENT, true );
+		$human_content = (string) get_post_meta( $post->ID, Constants::ACF_FIELD_HUMAN_CONTENT, true );
 
 		// Clean content for accurate comparison.
 		$ai_clean    = self::strip_region_prefix( $ai_content );

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -187,9 +187,8 @@ class AuditHelper {
 	/**
 	 * Primes WordPress' meta cache for a set of posts.
 	 *
-	 * Subsequent get_post_meta() calls on these posts hit the cache without
-	 * extra queries. Replaces a hand-rolled OR-query that bypassed the cache
-	 * and didn't scale on large months.
+	 * Call once before bulk get_post_meta() loops; subsequent reads on these
+	 * posts hit the cache without extra queries.
 	 *
 	 * @since 1.0.0
 	 *

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -23,21 +23,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Helper {
 
 	/**
-	 * Removes all plugin-related transients from database.
+	 * Removes all plugin-related transients from the database.
+	 *
+	 * Note: this only clears DB-backed transients. Sites with a persistent
+	 * object cache (Redis/Memcached) hold transients in cache, but those expire
+	 * naturally inside the rate-limit window (60s) so we don't enumerate them.
 	 *
 	 * @since 1.0.0
 	 */
 	public static function cleanup_transients(): void {
-		// Get all users to clean their rate limit transients.
-		$users = get_users( array( 'fields' => 'ID' ) );
-
-		foreach ( $users as $user_id ) {
-			$transient_key = Constants::get_rate_limit_key( $user_id );
-			delete_transient( $transient_key );
-		}
-
-		// Clean up orphaned transients using direct query.
-		// Delete both _transient_ and _transient_timeout_ entries.
 		global $wpdb;
 
 		// Clean rate limit transients (value + timeout).

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -25,9 +25,9 @@ class Helper {
 	/**
 	 * Removes all plugin-related transients from the database.
 	 *
-	 * Note: this only clears DB-backed transients. Sites with a persistent
-	 * object cache (Redis/Memcached) hold transients in cache, but those expire
-	 * naturally inside the rate-limit window (60s) so we don't enumerate them.
+	 * Only called on deactivation and uninstall, so any persistent-object-cache
+	 * entries that survive this DB cleanup have no live reader and expire on
+	 * their own TTL.
 	 *
 	 * @since 1.0.0
 	 */

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -14,7 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use ZW_TTVGPT_Core\AuditHelper;
 use ZW_TTVGPT_Core\AuditStatus;
-use ZW_TTVGPT_Core\Helper;
 
 /**
  * Audit Page class.
@@ -42,9 +41,18 @@ class AuditPage {
 			'month'         => isset( $_GET['month'] ) ? absint( $_GET['month'] ) : null,
 			'status_filter' => isset( $_GET['status'] ) ? sanitize_text_field( $_GET['status'] ) : '',
 			'change_filter' => isset( $_GET['change'] ) ? sanitize_text_field( $_GET['change'] ) : '',
+			'paged'         => isset( $_GET['paged'] ) ? max( 1, absint( $_GET['paged'] ) ) : 1,
 		);
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
+
+	/**
+	 * Posts shown per page on the audit overview.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	private const int POSTS_PER_PAGE = 50;
 
 	/**
 	 * Renders the audit analysis page.
@@ -57,6 +65,7 @@ class AuditPage {
 		$month         = $params['month'];
 		$status_filter = $params['status_filter'];
 		$change_filter = $params['change_filter'];
+		$paged         = $params['paged'];
 
 		if ( ! $year || ! $month ) {
 			$most_recent = AuditHelper::get_most_recent_month();
@@ -85,13 +94,13 @@ class AuditPage {
 			AuditStatus::AiWrittenEdited->value    => 0,
 		);
 
-		// Bulk fetch all meta data in one query to avoid N+1 problem.
-		$post_ids   = array_map( static fn( $post ) => $post->ID, $posts );
-		$meta_cache = AuditHelper::get_bulk_meta_data( $post_ids );
+		// Prime WordPress' meta cache so categorize_post's get_post_meta calls hit cache.
+		$post_ids = array_map( static fn( $post ) => $post->ID, $posts );
+		AuditHelper::prime_meta_cache( $post_ids );
 
 		$categorized_posts = array();
 		foreach ( $posts as $post ) {
-			$analysis = AuditHelper::categorize_post( $post, $meta_cache );
+			$analysis = AuditHelper::categorize_post( $post );
 			$status   = $analysis['status'];
 			++$counts[ $status->value ];
 
@@ -117,25 +126,49 @@ class AuditPage {
 
 		$available_months = AuditHelper::get_months();
 
-		// Load audit CSS for improved card spacing.
-		$version = Helper::get_asset_version();
-		wp_enqueue_style( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.css', array(), $version );
-		wp_print_styles( array( 'zw-ttvgpt-audit' ) );
+		// Slice filtered results for the requested page.
+		$total_filtered = count( $categorized_posts );
+		$total_pages    = (int) ceil( $total_filtered / self::POSTS_PER_PAGE );
+		$paged          = $total_pages > 0 ? min( $paged, $total_pages ) : 1;
+		$page_offset    = ( $paged - 1 ) * self::POSTS_PER_PAGE;
+		$page_slice     = array_slice( $categorized_posts, $page_offset, self::POSTS_PER_PAGE );
 
-		// Enqueue WordPress ThickBox for modal functionality.
+		// Stylesheet is enqueued by AdminMenu on the audit page hook.
 		add_thickbox();
 		?>
 		<div class="wrap">
 			<h1 class="wp-heading-inline"><?php esc_html_e( 'Tekst TV GPT - Auditlog', 'zw-ttvgpt' ); ?></h1>
 			<hr class="wp-header-end">
-			
+
 			<?php $this->render_status_links( $year, $month, $status_filter, $counts ); ?>
-			
+
 			<form id="posts-filter" method="get">
 				<input type="hidden" name="page" value="zw-ttvgpt-audit">
-				<?php $this->render_tablenav( $year, $month, $available_months, $status_filter, $change_filter, $counts, 'top' ); ?>
-				<?php $this->render_audit_table( $categorized_posts, $meta_cache ); ?>
-				<?php $this->render_tablenav( $year, $month, $available_months, $status_filter, $change_filter, $counts, 'bottom' ); ?>
+				<?php
+				$this->render_tablenav(
+					$year,
+					$month,
+					$available_months,
+					$status_filter,
+					$change_filter,
+					$total_filtered,
+					$paged,
+					$total_pages,
+					'top'
+				);
+				$this->render_audit_table( $page_slice );
+				$this->render_tablenav(
+					$year,
+					$month,
+					$available_months,
+					$status_filter,
+					$change_filter,
+					$total_filtered,
+					$paged,
+					$total_pages,
+					'bottom'
+				);
+				?>
 			</form>
 		</div>
 		<?php
@@ -204,11 +237,12 @@ class AuditPage {
 	 * @param array  $available_months All available months with data.
 	 * @param string $status_filter    Current status filter value.
 	 * @param string $change_filter    Current change percentage filter value.
-	 * @param array  $counts           Statistics counts for each category.
+	 * @param int    $total_filtered   Total items matching the current filters.
+	 * @param int    $paged            Current page number (1-indexed).
+	 * @param int    $total_pages      Total page count for the filtered set.
 	 * @param string $which            Position of navigation ('top' or 'bottom').
 	 *
 	 * @phpstan-param array<int, MonthData> $available_months
-	 * @phpstan-param array<value-of<AuditStatus>, int> $counts
 	 */
 	private function render_tablenav(
 		int $year,
@@ -216,10 +250,11 @@ class AuditPage {
 		array $available_months,
 		string $status_filter,
 		string $change_filter,
-		array $counts,
+		int $total_filtered,
+		int $paged,
+		int $total_pages,
 		string $which
 	): void {
-		$total = array_sum( $counts );
 		?>
 		<div class="tablenav <?php echo esc_attr( $which ); ?>">
 			<?php if ( 'top' === $which ) : ?>
@@ -273,11 +308,52 @@ class AuditPage {
 
 			<h2 class="screen-reader-text"><?php esc_html_e( 'Auditlijst navigatie', 'zw-ttvgpt' ); ?></h2>
 			<div class="tablenav-pages">
-				<span class="displaying-num"><?php echo esc_html( (string) $total ); ?> items</span>
+				<span class="displaying-num">
+					<?php
+					printf(
+						/* translators: %s: total item count */
+						esc_html( _n( '%s item', '%s items', $total_filtered, 'zw-ttvgpt' ) ),
+						esc_html( number_format_i18n( $total_filtered ) )
+					);
+					?>
+				</span>
+				<?php $this->render_pagination_links( $paged, $total_pages ); ?>
 			</div>
 			<br class="clear">
 		</div>
 		<?php
+	}
+
+	/**
+	 * Renders WordPress-style pagination links preserving current filters.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $paged       Current page (1-indexed).
+	 * @param int $total_pages Total number of pages.
+	 */
+	private function render_pagination_links( int $paged, int $total_pages ): void {
+		if ( $total_pages < 2 ) {
+			return;
+		}
+
+		$links = paginate_links(
+			array(
+				'base'      => add_query_arg( 'paged', '%#%' ),
+				'format'    => '',
+				'prev_text' => __( '&laquo;', 'zw-ttvgpt' ),
+				'next_text' => __( '&raquo;', 'zw-ttvgpt' ),
+				'total'     => $total_pages,
+				'current'   => $paged,
+				'type'      => 'plain',
+			)
+		);
+
+		if ( empty( $links ) ) {
+			return;
+		}
+
+		echo '<span class="pagination-links">' . wp_kses_post( $links ) . '</span>';
 	}
 
 	/**
@@ -286,12 +362,10 @@ class AuditPage {
 	 * @since 1.0.0
 	 *
 	 * @param array $categorized_posts Array of categorized posts with analysis data.
-	 * @param array $meta_cache        Pre-fetched meta data cache.
 	 *
 	 * @phpstan-param array<int, array<string, mixed>> $categorized_posts
-	 * @phpstan-param array<int, array<string, string>> $meta_cache
 	 */
-	private function render_audit_table( array $categorized_posts, array $meta_cache ): void {
+	private function render_audit_table( array $categorized_posts ): void {
 		?>
 		<h2 class="screen-reader-text"><?php esc_html_e( 'Auditlog', 'zw-ttvgpt' ); ?></h2>
 		<table class="wp-list-table widefat fixed striped table-view-list posts zw-audit-table">
@@ -320,7 +394,7 @@ class AuditPage {
 						$ai_content    = $item['ai_content'];
 						$human_content = $item['human_content'];
 						$author_data   = get_userdata( $post->post_author );
-						$edit_last     = $meta_cache[ $post->ID ]['_edit_last'] ?? '';
+						$edit_last     = get_post_meta( $post->ID, '_edit_last', true );
 						$editor_data   = is_numeric( $edit_last ) ? get_userdata( (int) $edit_last ) : null;
 						$post_url      = get_edit_post_link( $post->ID );
 						?>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,7 +14,7 @@ parameters:
     # Settings types
     PluginSettings: 'array{api_key: string, model: string, word_limit: int, system_prompt: string, debug_mode: bool}'
     # Audit types
-    FilterParams: 'array{year: int|null, month: int|null, status_filter: string, change_filter: string}'
+    FilterParams: 'array{year: int|null, month: int|null, status_filter: string, change_filter: string, paged: int}'
     MonthData: 'array{year: int, month: int}'
     PostAnalysis: 'array{status: ZW_TTVGPT_Core\AuditStatus, ai_content: string, human_content: string, change_percentage: int}'
     DiffResult: 'array{before: string, after: string}'


### PR DESCRIPTION
## Summary

Third batch from the full-plugin code review.

- **AuditHelper bulk meta** — `get_bulk_meta_data` built a hand-rolled OR-query that bypassed WordPress' object cache. Replaced with `update_meta_cache('post', $ids)` which primes the cache in one trip, after which `get_post_meta` is a cache hit. `categorize_post` drops its `$meta_cache` parameter.
- **Audit pagination (render-only)** — month view used to render every matching post in a single table, generating a diff modal per row. Now sliced at 50/page with `paginate_links`. **Note:** the underlying `WP_Query` still uses `posts_per_page => -1` and `AuditPage::render` categorizes the full month before slicing — the bound is on rendered rows and diff generation, not on the DB query. Filter counts in the subsubsub header reflect the full month (correctness > cheapness).
- **Duplicate CSS enqueue** — `AuditPage::render` was enqueueing + `wp_print_styles` for `zw-ttvgpt-audit`, but `AdminMenu` already enqueues that stylesheet on the audit page hook. The duplicate also fired mid-body after `admin_print_styles` had run. Dropped.
- **cleanup_transients** — the `get_users()` + per-user `delete_transient()` loop duplicated work that the SQL DELETE underneath already covered. The function only runs on deactivation/uninstall, so any persistent-object-cache entries that survive the DB cleanup have no live reader and expire on their own TTL. Dropped the loop.

## Test plan

- [x] `vendor/bin/phpcs` — clean
- [x] `vendor/bin/phpstan analyse --memory-limit=2G` — clean
- [x] `npm run lint` — clean
- [x] `vendor/bin/phpunit` — 18/18 (note: existing suite only covers `Helper::count_words`; does not exercise this PR's surface)
- [ ] Manual: open audit page on a month with >50 articles; confirm pagination shows and links preserve filters
- [ ] Manual: confirm change/status counts at top still reflect the full month, not the page slice
- [ ] Manual: confirm the audit table renders identically when ACF metadata is present
- [ ] Manual: confirm empty-filter state (no matching posts) still renders cleanly