### PR TITLE
refactor: harden audit diff sanitization and extract inline scripts

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1,7 +1,3 @@
-/**
- * ZW TTVGPT Admin Styles
- */
-
 /* Status messages */
 .zw-ttvgpt-status {
     padding: 10px;
@@ -87,7 +83,7 @@
     color: #fff;
 }
 
-/* Add shimmer effect to button while generating */
+/* Button shimmer */
 .button.zw-ttvgpt-generating::after {
     position: absolute;
     top: -50%;

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,11 +1,4 @@
-/**
- * ZW TTVGPT Admin JavaScript (ES Module)
- *
- * Manages summary generation interface with typing animations and loading states.
- * Uses native ES modules (WordPress 6.5+) with wp_enqueue_script_module.
- *
- * @package ZW_TTVGPT
- */
+/** Admin editor summary generation UI. */
 
 const SELECTORS = {
     contentEditor: '.wp-editor-area',
@@ -51,24 +44,11 @@ function shuffle(array) {
     return result;
 }
 
-/**
- * Query selector helper
- *
- * @param {string}           selector CSS selector.
- * @param {Element|Document} context  Context element.
- * @return {Element|null} Found element or null.
- */
+// DOM query helpers.
 function $(selector, context = document) {
     return context.querySelector(selector);
 }
 
-/**
- * Query selector all helper
- *
- * @param {string}           selector CSS selector.
- * @param {Element|Document} context  Context element.
- * @return {NodeList} Found elements.
- */
 function $$(selector, context = document) {
     return context.querySelectorAll(selector);
 }
@@ -150,7 +130,6 @@ function injectGenerateButton() {
         return;
     }
 
-    // Create container for button and word counter
     const container = document.createElement('div');
     container.className = 'zw-ttvgpt-controls';
     container.style.cssText =
@@ -163,7 +142,6 @@ function injectGenerateButton() {
     button.dataset.postId = postIdField ? postIdField.value : '';
     button.textContent = window.zwTTVGPT.strings.buttonText;
 
-    // Create word counter element
     cachedWordCounter = document.createElement('span');
     cachedWordCounter.className = 'zw-ttvgpt-word-counter';
     cachedWordCounter.setAttribute('aria-live', 'polite');
@@ -174,12 +152,10 @@ function injectGenerateButton() {
 
     button.addEventListener('click', handleGenerateClick);
 
-    // Bind input events for real-time word count updates
     cachedAcfField.addEventListener('input', updateWordCounter);
     cachedAcfField.addEventListener('change', updateWordCounter);
     cachedAcfField.addEventListener('keyup', updateWordCounter);
 
-    // Initial word count update
     updateWordCounter();
 }
 
@@ -210,7 +186,6 @@ async function handleGenerateClick(e) {
 
     const regions = getSelectedRegions();
 
-    // Debug: log content being sent to API
     if (window.zwTTVGPT.debugMode) {
         console.log('ZW TTVGPT Debug - Content wordt verstuurd naar API:');
         console.log('Post ID:', postId);
@@ -246,12 +221,11 @@ async function handleGenerateClick(e) {
             throw new Error(`Server error: ${response.status}`);
         }
 
-        // Check for HTTP errors, but use server message if available
+        // Let server-provided error messages pass through.
         if (!response.ok && !data?.data?.message) {
             throw new Error(`Server error: ${response.status}`);
         }
 
-        // Debug: log API response
         if (window.zwTTVGPT.debugMode) {
             console.log('ZW TTVGPT Debug - API Response:', data);
         }
@@ -265,7 +239,6 @@ async function handleGenerateClick(e) {
                 data.data?.message || window.zwTTVGPT.strings.error;
             showStatus('error', errorMessage);
 
-            // Log error code for debugging.
             if (window.zwTTVGPT.debugMode && data.data?.code) {
                 console.error('ZW TTVGPT Error Code:', data.data.code);
             }
@@ -292,11 +265,9 @@ async function handleGenerateClick(e) {
  * @return {string} Plain text content.
  */
 function getBlockText(block) {
-    // Get inner HTML from block and strip tags using WordPress built-in
     const html = window.wp.blocks.getBlockContent(block);
     const text = window.wp.sanitize.stripTags(html);
 
-    // Process inner blocks recursively
     if (block.innerBlocks && block.innerBlocks.length > 0) {
         const innerText = block.innerBlocks
             .map(getBlockText)
@@ -316,7 +287,6 @@ function getBlockText(block) {
 function getEditorContent() {
     let content = '';
 
-    // Try Block Editor (Gutenberg) first
     if (
         typeof window.wp !== 'undefined' &&
         window.wp.data &&
@@ -326,7 +296,6 @@ function getEditorContent() {
         const blocks = editor.getBlocks();
 
         if (blocks && blocks.length > 0) {
-            // Extract text from each block
             const textParts = blocks.map(getBlockText).filter(Boolean);
             content = textParts.join('\n\n');
 
@@ -336,7 +305,6 @@ function getEditorContent() {
         }
     }
 
-    // Try TinyMCE (Classic Editor) - already returns plain text
     if (
         typeof window.tinyMCE !== 'undefined' &&
         window.tinyMCE.activeEditor &&
@@ -349,7 +317,6 @@ function getEditorContent() {
         }
     }
 
-    // Fallback to textarea - strip HTML for safety
     const textarea = $(SELECTORS.contentEditor);
     if (textarea) {
         content = textarea.value;
@@ -372,47 +339,30 @@ function cleanupWhitespace(text) {
         return '';
     }
 
+    // Normalize paragraph breaks and inline whitespace.
     return text
-        .replace(/\n{3,}/g, '\n\n') // Max 2 consecutive newlines
-        .replace(/[ \t]+/g, ' ') // Multiple spaces/tabs to single space
-        .trim(); // Remove leading/trailing whitespace
+        .replace(/\n{3,}/g, '\n\n')
+        .replace(/[ \t]+/g, ' ')
+        .trim();
 }
 
-/**
- * Check if checkbox is from Block Editor.
- *
- * @param {Element} checkbox Checkbox element.
- * @return {boolean} True if Block Editor checkbox.
- */
+// Editor checkbox label helpers.
 function isBlockEditorCheckbox(checkbox) {
     const id = checkbox.id;
     return id?.startsWith('inspector-checkbox-control') ?? false;
 }
 
-/**
- * Get label text for Block Editor checkbox.
- *
- * @param {Element} checkbox Checkbox element.
- * @return {string} Label text.
- */
 function getBlockEditorLabel(checkbox) {
     const label = $(`label[for="${checkbox.id}"]`);
     return label ? label.textContent.trim() : '';
 }
 
-/**
- * Get label text for Classic Editor checkbox.
- *
- * @param {Element} checkbox Checkbox element.
- * @return {string} Label text.
- */
 function getClassicEditorLabel(checkbox) {
     const parent = checkbox.parentElement;
     if (!parent) {
         return '';
     }
 
-    // Get text nodes only
     let text = '';
     for (const node of parent.childNodes) {
         if (node.nodeType === Node.TEXT_NODE) {
@@ -429,7 +379,6 @@ function getClassicEditorLabel(checkbox) {
  * @return {Array<string>} Array of selected region names.
  */
 function getSelectedRegions() {
-    // Try Block Editor first, fallback to Classic Editor
     let checkboxes = $$(
         '.editor-post-taxonomies__hierarchical-terms-list input[type="checkbox"]:checked',
     );
@@ -477,7 +426,6 @@ function startThinkingAnimation(element, text = '') {
     const interval = setInterval(() => {
         const char = THINKING_CHARS[index % THINKING_CHARS.length];
         if (isButton) {
-            // Use textContent for security (no HTML injection)
             element.textContent = char + (text ? ` ${text}` : '');
         } else {
             element.value = char;
@@ -498,8 +446,7 @@ function handleSuccess(data, button) {
     const state = elementState.get(cachedAcfField) || {};
     const messageCount = state.messageCount || 0;
 
-    // Calculate wait time based on how many loading messages have been shown.
-    // We want at least 2 messages displayed before showing the result.
+    // Wait until at least two loading messages have shown.
     let waitTime;
     if (messageCount === 0) {
         waitTime = MESSAGE_TIMING.waitForBothMessages;
@@ -528,14 +475,12 @@ function handleSuccess(data, button) {
 function animateText(element, text, button, warning = null) {
     let index = 0;
 
-    // Clear any loading messages interval
     const state = elementState.get(element);
     if (state?.messageInterval) {
         clearInterval(state.messageInterval);
         elementState.delete(element);
     }
 
-    // Small delay to prevent collision with loading messages
     setTimeout(() => {
         element.value = '';
         element.disabled = true;
@@ -544,17 +489,14 @@ function animateText(element, text, button, warning = null) {
 
     function typeCharacter() {
         if (index < text.length) {
-            // Type multiple characters at once - faster
             const charsToType = Math.floor(Math.random() * 6) + 2; // 2-7 chars
             const newText = text.slice(index, index + charsToType);
             index += newText.length;
 
             element.value += newText;
 
-            // Scroll to bottom if needed
             element.scrollTop = element.scrollHeight;
 
-            // Simplified delay calculation
             const lastChar = text.charAt(index - 1);
             let delayConfig = TYPING_DELAYS.default;
 
@@ -569,18 +511,14 @@ function animateText(element, text, button, warning = null) {
             const delay = delayConfig[0] + Math.random() * delayConfig[1];
             setTimeout(typeCharacter, delay);
         } else {
-            // Re-enable field immediately when done
             element.disabled = false;
 
-            // Update word counter with final text
             updateWordCounter();
 
-            // Show warning if validation failed
             if (warning) {
                 showStatus('warning', warning);
             }
 
-            // Ensure button is re-enabled when typing completes
             if (button && button.dataset.isGenerating === 'true') {
                 setLoadingState(button, false);
                 button.dataset.isGenerating = 'false';
@@ -600,14 +538,12 @@ function setLoadingState(button, isLoading) {
         button.disabled = true;
         button.classList.add('zw-ttvgpt-generating');
 
-        // Start thinking animation
         const interval = startThinkingAnimation(
             button,
             window.zwTTVGPT.strings.generating,
         );
         elementState.set(button, { thinkingInterval: interval });
     } else {
-        // Clear thinking animation
         const state = elementState.get(button);
         if (state?.thinkingInterval) {
             clearInterval(state.thinkingInterval);
@@ -627,12 +563,10 @@ function setLoadingState(button, isLoading) {
  * @param {string} message Message text to display.
  */
 function showStatus(type, message) {
-    // Create a temporary notice above the ACF field
     if (!cachedAcfField) {
         return;
     }
 
-    // Remove any existing status
     const existingStatus = $('.zw-ttvgpt-status');
     if (existingStatus) {
         existingStatus.remove();
@@ -648,14 +582,13 @@ function showStatus(type, message) {
     status.className = `notice ${cssClass} zw-ttvgpt-status`;
     status.style.margin = '10px 0';
 
-    // Create paragraph element safely without innerHTML
+    // Avoid innerHTML for untrusted messages.
     const paragraph = document.createElement('p');
     paragraph.textContent = message;
     status.appendChild(paragraph);
 
     cachedAcfField.parentElement.insertBefore(status, cachedAcfField);
 
-    // Auto-hide success and warning messages
     if (type === 'success' || type === 'warning') {
         const timeouts = {
             warning: 8000,
@@ -701,22 +634,18 @@ function showLoadingMessages() {
         return;
     }
 
-    // Create a shuffled copy of messages
     let messages = shuffle(window.zwTTVGPT.strings.loadingMessages);
     let messageIndex = 0;
     let messageCount = 0;
     let activeTransition = null;
 
-    // Clear the field and disable it
     cachedAcfField.disabled = true;
     cachedAcfField.placeholder = '';
 
-    // Show first message immediately
     cachedAcfField.value = messages[messageIndex];
     messageIndex++;
     messageCount++;
 
-    // Update state helper
     function updateState() {
         elementState.set(cachedAcfField, {
             messageInterval,
@@ -725,24 +654,19 @@ function showLoadingMessages() {
         });
     }
 
-    // Function to show next message
     function showNextMessage() {
         if (messageIndex >= messages.length) {
-            // Reshuffle when we've shown all messages
             messages = shuffle(messages);
             messageIndex = 0;
         }
 
-        // Get next message
         const nextMessage = messages[messageIndex];
         let charIndex = 0;
 
-        // Clear any existing transition
         if (activeTransition) {
             clearInterval(activeTransition);
         }
 
-        // Gradually replace current text with next message
         activeTransition = setInterval(() => {
             if (charIndex <= nextMessage.length) {
                 cachedAcfField.value = nextMessage.substring(0, charIndex);
@@ -759,18 +683,14 @@ function showLoadingMessages() {
         updateState();
     }
 
-    // Show second message quickly, then normal speed for rest
     setTimeout(showNextMessage, MESSAGE_TIMING.firstMessageDelay);
 
-    // Then cycle through remaining messages at normal speed
     const messageInterval = setInterval(
         showNextMessage,
         MESSAGE_TIMING.messageInterval,
     );
 
-    // Store initial state
     updateState();
 }
 
-// Initialize when ready
 init();

--- a/assets/audit.js
+++ b/assets/audit.js
@@ -9,7 +9,11 @@
  */
 
 const config = window.zwTTVGPTAudit;
-if (config) {
+if (!config) {
+    console.warn(
+        'zw-ttvgpt: audit config missing, filter handlers not attached',
+    );
+} else {
     const date = document.getElementById('filter-by-date');
     const status = document.getElementById('filter-by-status');
     const change = document.getElementById('filter-by-change');

--- a/assets/audit.js
+++ b/assets/audit.js
@@ -1,0 +1,47 @@
+/**
+ * ZW TTVGPT Audit page JavaScript (ES Module).
+ *
+ * Submits the filter form via plain navigation when any of the dropdowns
+ * change, preserving WordPress' tablenav conventions without depending on
+ * jQuery. Configuration arrives via window.zwTTVGPTAudit.
+ *
+ * @package ZW_TTVGPT
+ */
+
+const config = window.zwTTVGPTAudit;
+if (config) {
+    const date = document.getElementById('filter-by-date');
+    const status = document.getElementById('filter-by-status');
+    const change = document.getElementById('filter-by-change');
+    const submit = document.getElementById('post-query-submit');
+
+    function applyFilters() {
+        const params = new URLSearchParams();
+        params.set('page', 'zw-ttvgpt-audit');
+
+        const dateValue = date?.value ?? '';
+        if (dateValue && dateValue !== '0') {
+            params.set('year', dateValue.substring(0, 4));
+            params.set(
+                'month',
+                String(parseInt(dateValue.substring(4, 6), 10)),
+            );
+        }
+        if (status?.value) {
+            params.set('status', status.value);
+        }
+        if (change?.value) {
+            params.set('change', change.value);
+        }
+
+        window.location.href = `${config.baseUrl}?${params.toString()}`;
+    }
+
+    for (const el of [date, status, change]) {
+        el?.addEventListener('change', applyFilters);
+    }
+    submit?.addEventListener('click', (e) => {
+        e.preventDefault();
+        applyFilters();
+    });
+}

--- a/assets/audit.js
+++ b/assets/audit.js
@@ -1,12 +1,4 @@
-/**
- * ZW TTVGPT Audit page JavaScript (ES Module).
- *
- * Submits the filter form via plain navigation when any of the dropdowns
- * change, preserving WordPress' tablenav conventions without depending on
- * jQuery. Configuration arrives via window.zwTTVGPTAudit.
- *
- * @package ZW_TTVGPT
- */
+/** Submit audit filters via navigation to preserve WP tablenav behavior. */
 
 const config = window.zwTTVGPTAudit;
 if (!config) {

--- a/assets/settings.js
+++ b/assets/settings.js
@@ -1,11 +1,4 @@
-/**
- * ZW TTVGPT Settings page JavaScript (ES Module).
- *
- * Toggles the legacy fine-tuned model input when the matching select option
- * is chosen. Configuration arrives via window.zwTTVGPTSettings.
- *
- * @package ZW_TTVGPT
- */
+/** Toggle the legacy fine-tuned model field. */
 
 const config = window.zwTTVGPTSettings;
 if (!config) {

--- a/assets/settings.js
+++ b/assets/settings.js
@@ -1,0 +1,38 @@
+/**
+ * ZW TTVGPT Settings page JavaScript (ES Module).
+ *
+ * Toggles the legacy fine-tuned model input when the matching select option
+ * is chosen. Configuration arrives via window.zwTTVGPTSettings.
+ *
+ * @package ZW_TTVGPT
+ */
+
+const config = window.zwTTVGPTSettings;
+if (config) {
+    const select = document.getElementById('zw_ttvgpt_model_select');
+    const wrapper = document.getElementById(
+        'zw_ttvgpt_legacy_fine_tuned_wrapper',
+    );
+    const legacyInput = document.getElementById(
+        'zw_ttvgpt_legacy_fine_tuned_model',
+    );
+
+    if (select && wrapper && legacyInput) {
+        const { fieldName, legacyOptionValue } = config;
+
+        select.addEventListener('change', () => {
+            const isLegacy = select.value === legacyOptionValue;
+            wrapper.style.display = isLegacy ? 'block' : 'none';
+
+            if (isLegacy) {
+                select.removeAttribute('name');
+                legacyInput.setAttribute('name', fieldName);
+                legacyInput.setAttribute('required', 'required');
+            } else {
+                select.setAttribute('name', fieldName);
+                legacyInput.removeAttribute('name');
+                legacyInput.removeAttribute('required');
+            }
+        });
+    }
+}

--- a/assets/settings.js
+++ b/assets/settings.js
@@ -8,7 +8,11 @@
  */
 
 const config = window.zwTTVGPTSettings;
-if (config) {
+if (!config) {
+    console.warn(
+        'zw-ttvgpt: settings config missing, legacy model toggle inactive',
+    );
+} else {
     const select = document.getElementById('zw_ttvgpt_model_select');
     const wrapper = document.getElementById(
         'zw_ttvgpt_legacy_fine_tuned_wrapper',

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "phpstan/extension-installer": "^1.3",
         "phpunit/phpunit": "^12",
+        "roots/wordpress-no-content": "^6.9",
         "squizlabs/php_codesniffer": "^3.8",
         "szepeviktor/phpstan-wordpress": "^2.0",
         "wp-coding-standards/wpcs": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "phpstan/extension-installer": "^1.3",
         "phpunit/phpunit": "^12",
-        "roots/wordpress-no-content": "^6.9",
+        "roots/wordpress-no-content": "^6.8",
         "squizlabs/php_codesniffer": "^3.8",
         "szepeviktor/phpstan-wordpress": "^2.0",
         "wp-coding-standards/wpcs": "^3.0"

--- a/includes/ApiHandler.php
+++ b/includes/ApiHandler.php
@@ -90,8 +90,7 @@ class ApiHandler {
 	 * @return string Cleaned content ready for API.
 	 */
 	public function prepare_content( string $content ): string {
-		// Remove script and style elements WITH their content.
-		// wp_strip_all_tags() only removes tags, not the content inside.
+		// Remove script-like elements including their content; wp_strip_all_tags() only removes tags.
 		$content = preg_replace( '/<script\b[^>]*>.*?<\/script>/is', '', $content ) ?? $content;
 		$content = preg_replace( '/<style\b[^>]*>.*?<\/style>/is', '', $content ) ?? $content;
 		$content = preg_replace( '/<noscript\b[^>]*>.*?<\/noscript>/is', '', $content ) ?? $content;
@@ -100,10 +99,8 @@ class ApiHandler {
 		$content = preg_replace( '/<\/(p|div|h[1-6]|li|tr|blockquote)>/i', "\n", $content ) ?? $content;
 		$content = preg_replace( '/<br\s*\/?>/i', "\n", $content ) ?? $content;
 
-		// Strip remaining tags.
 		$text = wp_strip_all_tags( $content );
 
-		// Decode HTML entities.
 		$text = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 
 		// Normalize whitespace.
@@ -184,8 +181,7 @@ class ApiHandler {
 	 * @phpstan-return array<string, mixed>
 	 */
 	private function build_responses_request( string $content, int $word_limit ): array {
-		// Using 'low' reasoning effort for quality summaries while maintaining speed.
-		// Using 'medium' verbosity for balanced response length.
+		// Tune Responses API output for fast, moderately detailed summaries.
 		return array(
 			'model'             => $this->model,
 			'input'             => $this->build_messages( $content, $word_limit ),
@@ -367,7 +363,6 @@ class ApiHandler {
 			);
 		}
 
-		// Build request based on API type.
 		if ( $is_gpt5 ) {
 			$request_data = $this->build_responses_request( $content, $word_limit );
 		} else {
@@ -428,7 +423,6 @@ class ApiHandler {
 			);
 		}
 
-		// Extract summary based on API type.
 		if ( $is_gpt5 ) {
 			$summary = $this->extract_responses_summary( $data );
 		} else {

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -21,32 +21,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since   1.0.0
  */
 class AuditHelper {
-	/**
-	 * Diff class used for content added by a human edit.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
-	private const string DIFF_CLASS_ADDED = 'zw-diff-added';
-
-	/**
-	 * Diff class used for content removed from the AI version.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
+	private const string DIFF_CLASS_ADDED   = 'zw-diff-added';
 	private const string DIFF_CLASS_REMOVED = 'zw-diff-removed';
 
 	/**
-	 * Splits content for the WordPress diff renderer.
-	 *
-	 * Fails closed by returning the original content as a single chunk so the
-	 * caller still renders the unsplit text instead of an empty diff.
-	 *
-	 * @since 1.0.0
+	 * Splits content for Text_Diff. Returns the unsplit text on PCRE failure so
+	 * the caller still renders something instead of an empty diff.
 	 *
 	 * @param string $content Content to split.
-	 * @return array<int, string> Split content chunks.
+	 * @return array<int, string>
 	 */
 	private static function split_for_word_diff( string $content ): array {
 		$parts = preg_split( '/([.!?]\s+)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
@@ -58,50 +41,37 @@ class AuditHelper {
 	}
 
 	/**
-	 * Removes a diff class from the combined diff HTML.
-	 *
-	 * @since 1.0.0
+	 * Strips spans of the given diff class. Returns null on PCRE failure so the
+	 * caller can fall back to a plain-text pane.
 	 *
 	 * @param string $diff_html  Combined diff HTML.
 	 * @param string $class_name Diff class to remove.
-	 * @return string|null Filtered HTML, or null when PCRE failed so the caller can fall back to plain text.
 	 */
 	private static function remove_diff_class( string $diff_html, string $class_name ): ?string {
 		$pattern = '/<span class="' . preg_quote( $class_name, '/' ) . '">.*?<\/span>/s';
 		$result  = preg_replace( $pattern, '', $diff_html );
 
-		if ( null === $result ) {
-			return null;
-		}
-
-		return $result;
+		return null === $result ? null : $result;
 	}
 
 	/**
-	 * Normalizes whitespace in generated diff HTML.
-	 *
-	 * @since 1.0.0
+	 * Collapses whitespace runs in diff HTML; returns the input unchanged on PCRE failure.
 	 *
 	 * @param string $diff_html Diff HTML to normalize.
-	 * @return string Normalized HTML, or the original string if normalization fails.
 	 */
 	private static function normalize_diff_whitespace( string $diff_html ): string {
 		$normalized = preg_replace( '/\s+/', ' ', $diff_html );
-		if ( null === $normalized ) {
-			return $diff_html;
-		}
 
-		return $normalized;
+		return null === $normalized ? $diff_html : $normalized;
 	}
 
 	/**
-	 * Builds a safe plain-text fallback diff when highlighting cannot be trusted.
-	 *
-	 * @since 1.0.0
+	 * Plain-text fallback for both diff panes when highlighting cannot be trusted.
 	 *
 	 * @param string $old_clean      Original content after prefix stripping.
 	 * @param string $modified_clean Modified content after prefix stripping.
-	 * @return array{before: string, after: string} Safe before/after panes.
+	 *
+	 * @phpstan-return DiffResult
 	 */
 	private static function plain_diff_result( string $old_clean, string $modified_clean ): array {
 		return array(

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -144,7 +144,7 @@ class AuditHelper {
 	public static function get_most_recent_month(): ?array {
 		global $wpdb;
 
-		// Turbo-optimized: Target only recent posts for faster scanning.
+		// Limit the scan to recent posts for audit performance.
 		$result = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT p.post_date
@@ -181,7 +181,6 @@ class AuditHelper {
 			return null;
 		}
 
-		// Extract year and month from date string.
 		$year  = (int) substr( $result, 0, 4 );
 		$month = (int) substr( $result, 5, 2 );
 
@@ -235,7 +234,6 @@ class AuditHelper {
 			)
 		);
 
-		// Convert database results to array format.
 		$unique_months = array();
 		foreach ( $results as $row ) {
 			$unique_months[] = array(
@@ -353,11 +351,9 @@ class AuditHelper {
 		$ai_content    = (string) get_post_meta( $post->ID, Constants::ACF_FIELD_AI_CONTENT, true );
 		$human_content = (string) get_post_meta( $post->ID, Constants::ACF_FIELD_HUMAN_CONTENT, true );
 
-		// Clean content for accurate comparison.
 		$ai_clean    = self::strip_region_prefix( $ai_content );
 		$human_clean = self::strip_region_prefix( $human_content );
 
-		// Determine status based on content analysis using enum.
 		$status = match ( true ) {
 			empty( $ai_content ) || '' === trim( $ai_content ) => AuditStatus::FullyHumanWritten,
 			$ai_clean === $human_clean                         => AuditStatus::AiWrittenNotEdited,
@@ -408,7 +404,6 @@ class AuditHelper {
 		$old_lines      = self::split_for_word_diff( $old_clean, 'split original diff text' );
 		$modified_lines = self::split_for_word_diff( $modified_clean, 'split modified diff text' );
 
-		// Create the diff.
 		$text_diff = new \Text_Diff( 'auto', array( $old_lines, $modified_lines ) );
 		$renderer  = new \WP_Text_Diff_Renderer_inline();
 		$diff_html = $renderer->render( $text_diff );
@@ -457,7 +452,6 @@ class AuditHelper {
 			return 100.0;
 		}
 
-		// Split into words for comparison.
 		$ai_words_result    = preg_split( '/\s+/', trim( $ai_content ) );
 		$human_words_result = preg_split( '/\s+/', trim( $human_content ) );
 
@@ -474,11 +468,9 @@ class AuditHelper {
 		// Calculate similarity using simple word matching.
 		$max_words = max( $ai_word_count, $human_word_count );
 
-		// Find words that appear in both versions.
 		$common_words   = array_intersect( $ai_words, $human_words );
 		$matching_words = count( $common_words );
 
-		// Calculate change percentage.
 		$similarity_ratio  = $matching_words / $max_words;
 		$change_percentage = ( 1 - $similarity_ratio ) * 100;
 

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -213,10 +213,13 @@ class AuditHelper {
 	 * @return string Cleaned content without region prefix.
 	 */
 	public static function strip_region_prefix( string $content ): string {
-		// Remove region prefixes like "LEIDEN - ", "DEN HAAG - ", "ROOSENDAAL/OUDENBOSCH - ", "ETTEN-LEUR - ".
-		// Matches: uppercase letters, spaces, forward slashes, hyphens, followed by " - ".
-		$result = preg_replace( '/^[A-Z][A-Z\s\/\-]*\s-\s/', '', trim( $content ) );
-		return null !== $result ? $result : trim( $content );
+		// Region prefixes look like "LEIDEN - ", "DEN HAAG - ",
+		// "ROOSENDAAL/OUDENBOSCH - ", "ETTEN-LEUR - ", "CURAÇAO - ". The
+		// character class is Unicode-aware so diacritic uppercase letters
+		// (Ç, Ü, É, ...) still match.
+		$trimmed = trim( $content );
+		$result  = preg_replace( '/^\p{Lu}[\p{Lu}\s\/\-]*\s-\s/u', '', $trimmed );
+		return null !== $result ? $result : $trimmed;
 	}
 
 	/**

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -38,37 +38,19 @@ class AuditHelper {
 	private const string DIFF_CLASS_REMOVED = 'zw-diff-removed';
 
 	/**
-	 * Reports a PCRE failure from static audit helpers.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $operation Operation that failed.
-	 */
-	private static function report_regex_failure( string $operation ): void {
-		$error_code    = preg_last_error();
-		$error_message = preg_last_error_msg();
-
-		if ( function_exists( 'do_action' ) ) {
-			do_action( 'zw_ttvgpt_audit_regex_failed', $operation, $error_code, $error_message );
-		}
-
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Static helper has no injected Logger.
-		error_log( sprintf( '[ZW_TTVGPT] Audit regex failed during %s: %s', $operation, $error_message ) );
-	}
-
-	/**
 	 * Splits content for the WordPress diff renderer.
 	 *
+	 * Fails closed by returning the original content as a single chunk so the
+	 * caller still renders the unsplit text instead of an empty diff.
+	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $content   Content to split.
-	 * @param string $operation Operation label for telemetry.
+	 * @param string $content Content to split.
 	 * @return array<int, string> Split content chunks.
 	 */
-	private static function split_for_word_diff( string $content, string $operation ): array {
+	private static function split_for_word_diff( string $content ): array {
 		$parts = preg_split( '/([.!?]\s+)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
 		if ( false === $parts ) {
-			self::report_regex_failure( $operation );
 			return '' === $content ? array() : array( $content );
 		}
 
@@ -80,17 +62,15 @@ class AuditHelper {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $diff_html Combined diff HTML.
+	 * @param string $diff_html  Combined diff HTML.
 	 * @param string $class_name Diff class to remove.
-	 * @param string $operation Operation label for telemetry.
-	 * @return string|null Filtered HTML, or null when PCRE failed.
+	 * @return string|null Filtered HTML, or null when PCRE failed so the caller can fall back to plain text.
 	 */
-	private static function remove_diff_class( string $diff_html, string $class_name, string $operation ): ?string {
+	private static function remove_diff_class( string $diff_html, string $class_name ): ?string {
 		$pattern = '/<span class="' . preg_quote( $class_name, '/' ) . '">.*?<\/span>/s';
 		$result  = preg_replace( $pattern, '', $diff_html );
 
 		if ( null === $result ) {
-			self::report_regex_failure( $operation );
 			return null;
 		}
 
@@ -102,14 +82,12 @@ class AuditHelper {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $diff_html  Diff HTML to normalize.
-	 * @param string $operation  Operation label for telemetry.
+	 * @param string $diff_html Diff HTML to normalize.
 	 * @return string Normalized HTML, or the original string if normalization fails.
 	 */
-	private static function normalize_diff_whitespace( string $diff_html, string $operation ): string {
+	private static function normalize_diff_whitespace( string $diff_html ): string {
 		$normalized = preg_replace( '/\s+/', ' ', $diff_html );
 		if ( null === $normalized ) {
-			self::report_regex_failure( $operation );
 			return $diff_html;
 		}
 
@@ -327,7 +305,6 @@ class AuditHelper {
 		$trimmed = trim( $content );
 		$result  = preg_replace( '/^\p{Lu}{2,}[\p{Lu}\s\/\-]*\s-\s/u', '', $trimmed );
 		if ( null === $result ) {
-			self::report_regex_failure( 'strip region prefix' );
 			return $trimmed;
 		}
 
@@ -401,8 +378,8 @@ class AuditHelper {
 		}
 
 		// Split into lines for WordPress diff (works better with sentences).
-		$old_lines      = self::split_for_word_diff( $old_clean, 'split original diff text' );
-		$modified_lines = self::split_for_word_diff( $modified_clean, 'split modified diff text' );
+		$old_lines      = self::split_for_word_diff( $old_clean );
+		$modified_lines = self::split_for_word_diff( $modified_clean );
 
 		$text_diff = new \Text_Diff( 'auto', array( $old_lines, $modified_lines ) );
 		$renderer  = new \WP_Text_Diff_Renderer_inline();
@@ -421,16 +398,16 @@ class AuditHelper {
 		);
 
 		// Split the diff into before/after by removing the opposite tags.
-		$before = self::remove_diff_class( $diff_html, self::DIFF_CLASS_ADDED, 'remove added diff span for before pane' );
-		$after  = self::remove_diff_class( $diff_html, self::DIFF_CLASS_REMOVED, 'remove removed diff span for after pane' );
+		$before = self::remove_diff_class( $diff_html, self::DIFF_CLASS_ADDED );
+		$after  = self::remove_diff_class( $diff_html, self::DIFF_CLASS_REMOVED );
 
 		if ( null === $before || null === $after ) {
 			return self::plain_diff_result( $old_clean, $modified_clean );
 		}
 
 		return array(
-			'before' => trim( self::normalize_diff_whitespace( $before, 'normalize before diff whitespace' ) ),
-			'after'  => trim( self::normalize_diff_whitespace( $after, 'normalize after diff whitespace' ) ),
+			'before' => trim( self::normalize_diff_whitespace( $before ) ),
+			'after'  => trim( self::normalize_diff_whitespace( $after ) ),
 		);
 	}
 

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -216,9 +216,11 @@ class AuditHelper {
 		// Region prefixes look like "LEIDEN - ", "DEN HAAG - ",
 		// "ROOSENDAAL/OUDENBOSCH - ", "ETTEN-LEUR - ", "CURAÇAO - ". The
 		// character class is Unicode-aware so diacritic uppercase letters
-		// (Ç, Ü, É, ...) still match.
+		// (Ç, Ü, É, ...) still match. The leading `\p{Lu}{2,}` requires at
+		// least two uppercase letters so single-letter listicle prefixes
+		// like "A - eerste optie" are not mistaken for a region.
 		$trimmed = trim( $content );
-		$result  = preg_replace( '/^\p{Lu}[\p{Lu}\s\/\-]*\s-\s/u', '', $trimmed );
+		$result  = preg_replace( '/^\p{Lu}{2,}[\p{Lu}\s\/\-]*\s-\s/u', '', $trimmed );
 		return null !== $result ? $result : $trimmed;
 	}
 

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -52,7 +52,7 @@ class AuditHelper {
 			do_action( 'zw_ttvgpt_audit_regex_failed', $operation, $error_code, $error_message );
 		}
 
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Static helper has no injected Logger, and regex failures need production visibility.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Static helper has no injected Logger.
 		error_log( sprintf( '[ZW_TTVGPT] Audit regex failed during %s: %s', $operation, $error_message ) );
 	}
 
@@ -324,12 +324,8 @@ class AuditHelper {
 	 * @return string Cleaned content without region prefix.
 	 */
 	public static function strip_region_prefix( string $content ): string {
-		// Region prefixes look like "LEIDEN - ", "DEN HAAG - ",
-		// "ROOSENDAAL/OUDENBOSCH - ", "ETTEN-LEUR - ", "CURAÇAO - ". The
-		// character class is Unicode-aware so diacritic uppercase letters
-		// (Ç, Ü, É, ...) still match. The leading `\p{Lu}{2,}` requires at
-		// least two uppercase letters so single-letter listicle prefixes
-		// like "A - eerste optie" are not mistaken for a region.
+		// Match Unicode uppercase region prefixes while preserving one-letter
+		// list markers such as "A - eerste optie".
 		$trimmed = trim( $content );
 		$result  = preg_replace( '/^\p{Lu}{2,}[\p{Lu}\s\/\-]*\s-\s/u', '', $trimmed );
 		if ( null === $result ) {

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -22,6 +22,117 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class AuditHelper {
 	/**
+	 * Diff class used for content added by a human edit.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	private const string DIFF_CLASS_ADDED = 'zw-diff-added';
+
+	/**
+	 * Diff class used for content removed from the AI version.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	private const string DIFF_CLASS_REMOVED = 'zw-diff-removed';
+
+	/**
+	 * Reports a PCRE failure from static audit helpers.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $operation Operation that failed.
+	 */
+	private static function report_regex_failure( string $operation ): void {
+		$error_code    = preg_last_error();
+		$error_message = preg_last_error_msg();
+
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'zw_ttvgpt_audit_regex_failed', $operation, $error_code, $error_message );
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Static helper has no injected Logger, and regex failures need production visibility.
+		error_log( sprintf( '[ZW_TTVGPT] Audit regex failed during %s: %s', $operation, $error_message ) );
+	}
+
+	/**
+	 * Splits content for the WordPress diff renderer.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $content   Content to split.
+	 * @param string $operation Operation label for telemetry.
+	 * @return array<int, string> Split content chunks.
+	 */
+	private static function split_for_word_diff( string $content, string $operation ): array {
+		$parts = preg_split( '/([.!?]\s+)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+		if ( false === $parts ) {
+			self::report_regex_failure( $operation );
+			return '' === $content ? array() : array( $content );
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * Removes a diff class from the combined diff HTML.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $diff_html Combined diff HTML.
+	 * @param string $class_name Diff class to remove.
+	 * @param string $operation Operation label for telemetry.
+	 * @return string|null Filtered HTML, or null when PCRE failed.
+	 */
+	private static function remove_diff_class( string $diff_html, string $class_name, string $operation ): ?string {
+		$pattern = '/<span class="' . preg_quote( $class_name, '/' ) . '">.*?<\/span>/s';
+		$result  = preg_replace( $pattern, '', $diff_html );
+
+		if ( null === $result ) {
+			self::report_regex_failure( $operation );
+			return null;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Normalizes whitespace in generated diff HTML.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $diff_html  Diff HTML to normalize.
+	 * @param string $operation  Operation label for telemetry.
+	 * @return string Normalized HTML, or the original string if normalization fails.
+	 */
+	private static function normalize_diff_whitespace( string $diff_html, string $operation ): string {
+		$normalized = preg_replace( '/\s+/', ' ', $diff_html );
+		if ( null === $normalized ) {
+			self::report_regex_failure( $operation );
+			return $diff_html;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Builds a safe plain-text fallback diff when highlighting cannot be trusted.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $old_clean      Original content after prefix stripping.
+	 * @param string $modified_clean Modified content after prefix stripping.
+	 * @return array{before: string, after: string} Safe before/after panes.
+	 */
+	private static function plain_diff_result( string $old_clean, string $modified_clean ): array {
+		return array(
+			'before' => trim( htmlspecialchars( $old_clean, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ) ),
+			'after'  => trim( htmlspecialchars( $modified_clean, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ) ),
+		);
+	}
+
+	/**
 	 * Retrieves the most recent month that has relevant posts for audit analysis.
 	 *
 	 * @since 1.0.0
@@ -221,7 +332,12 @@ class AuditHelper {
 		// like "A - eerste optie" are not mistaken for a region.
 		$trimmed = trim( $content );
 		$result  = preg_replace( '/^\p{Lu}{2,}[\p{Lu}\s\/\-]*\s-\s/u', '', $trimmed );
-		return null !== $result ? $result : $trimmed;
+		if ( null === $result ) {
+			self::report_regex_failure( 'strip region prefix' );
+			return $trimmed;
+		}
+
+		return $result;
 	}
 
 	/**
@@ -293,8 +409,8 @@ class AuditHelper {
 		}
 
 		// Split into lines for WordPress diff (works better with sentences).
-		$old_lines      = preg_split( '/([.!?]\s+)/', $old_clean, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
-		$modified_lines = preg_split( '/([.!?]\s+)/', $modified_clean, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+		$old_lines      = self::split_for_word_diff( $old_clean, 'split original diff text' );
+		$modified_lines = self::split_for_word_diff( $modified_clean, 'split modified diff text' );
 
 		// Create the diff.
 		$text_diff = new \Text_Diff( 'auto', array( $old_lines, $modified_lines ) );
@@ -305,29 +421,25 @@ class AuditHelper {
 		$diff_html = str_replace(
 			array( '<ins>', '</ins>', '<del>', '</del>' ),
 			array(
-				'<span class="zw-diff-added">',
+				'<span class="' . self::DIFF_CLASS_ADDED . '">',
 				'</span>',
-				'<span class="zw-diff-removed">',
+				'<span class="' . self::DIFF_CLASS_REMOVED . '">',
 				'</span>',
 			),
 			$diff_html
 		);
 
 		// Split the diff into before/after by removing the opposite tags.
-		$before = preg_replace( '/<span class="zw-diff-added">.*?<\/span>/s', '', $diff_html );
-		$after  = preg_replace( '/<span class="zw-diff-removed">.*?<\/span>/s', '', $diff_html );
+		$before = self::remove_diff_class( $diff_html, self::DIFF_CLASS_ADDED, 'remove added diff span for before pane' );
+		$after  = self::remove_diff_class( $diff_html, self::DIFF_CLASS_REMOVED, 'remove removed diff span for after pane' );
 
-		// Clean up any double spaces - handle potential null from preg_replace.
-		$before = is_string( $before ) ? preg_replace( '/\s+/', ' ', $before ) : $diff_html;
-		$after  = is_string( $after ) ? preg_replace( '/\s+/', ' ', $after ) : $diff_html;
-
-		// Ensure before and after are strings before trimming.
-		$before = is_string( $before ) ? $before : '';
-		$after  = is_string( $after ) ? $after : '';
+		if ( null === $before || null === $after ) {
+			return self::plain_diff_result( $old_clean, $modified_clean );
+		}
 
 		return array(
-			'before' => trim( $before ),
-			'after'  => trim( $after ),
+			'before' => trim( self::normalize_diff_whitespace( $before, 'normalize before diff whitespace' ) ),
+			'after'  => trim( self::normalize_diff_whitespace( $after, 'normalize after diff whitespace' ) ),
 		);
 	}
 

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -80,12 +80,17 @@ class Helper {
 	}
 
 	/**
-	 * Validates OpenAI API key format.
+	 * Liveness check for an OpenAI API key.
+	 *
+	 * Verifies the key is non-empty and carries the OpenAI 'sk-' prefix used by
+	 * all current key flavours (sk-, sk-proj-, sk-svcacct-, sk-admin-). This is
+	 * intentionally not a strict format validator — the canonical key shape has
+	 * shifted over time, and a tight regex would reject valid future keys.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $api_key API key to validate.
-	 * @return bool True if key format is valid (starts with 'sk-'), false otherwise.
+	 * @param string $api_key API key to inspect.
+	 * @return bool True if the key looks like an OpenAI key, false otherwise.
 	 */
 	public static function is_valid_api_key( string $api_key ): bool {
 		return ! empty( $api_key ) && str_starts_with( $api_key, 'sk-' );

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Helper {
 
 	/**
-	 * Removes all plugin-related transients from the database.
+	 * Removes plugin-owned transient rows from wp_options.
 	 *
 	 * Only called on deactivation and uninstall, so any persistent-object-cache
 	 * entries that survive this DB cleanup have no live reader and expire on

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -80,12 +80,10 @@ class Helper {
 	}
 
 	/**
-	 * Liveness check for an OpenAI API key.
+	 * Checks whether an API key has the expected OpenAI prefix.
 	 *
-	 * Verifies the key is non-empty and carries the OpenAI 'sk-' prefix used by
-	 * all current key flavours (sk-, sk-proj-, sk-svcacct-, sk-admin-). This is
-	 * intentionally not a strict format validator — the canonical key shape has
-	 * shifted over time, and a tight regex would reject valid future keys.
+	 * Intentionally avoids strict key-shape validation so future key formats with
+	 * the same prefix are accepted.
 	 *
 	 * @since 1.0.0
 	 *

--- a/includes/Logger.php
+++ b/includes/Logger.php
@@ -91,7 +91,6 @@ class Logger {
 			$log_message .= ' | Context: ' . wp_json_encode( $context );
 		}
 
-		// Log to PHP error log for consistent error tracking.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Design choice for error tracking
 		error_log( $log_message );
 	}

--- a/includes/SummaryGenerator.php
+++ b/includes/SummaryGenerator.php
@@ -48,7 +48,6 @@ class SummaryGenerator {
 	 * @return never
 	 */
 	public function handle_ajax_request(): never {
-		// Nonce is verified in validate_ajax_request() method.
 		$this->validate_ajax_request( 'zw_ttvgpt_nonce', Constants::EDIT_CAPABILITY );
 
 		if ( empty( SettingsManager::get_api_key() ) ) {
@@ -186,7 +185,7 @@ class SummaryGenerator {
 			}
 		}
 
-		// All attempts exhausted - return last attempt for user to manually adjust.
+		// Return the last attempt so the user can adjust it manually.
 		$this->logger->debug(
 			sprintf( 'Summary retry limit reached (%d attempts), returning last attempt', Constants::MAX_RETRY_ATTEMPTS )
 		);

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -173,7 +173,10 @@ class AdminMenu {
 	private function print_inline_config( string $global_name, array $config ): bool {
 		$json = wp_json_encode( $config );
 		if ( false === $json ) {
-			$this->logger->error( sprintf( 'Failed to encode inline config for window.%s', $global_name ) );
+			$this->logger->error(
+				sprintf( 'Failed to encode inline config for window.%s', $global_name ),
+				array( 'json_error' => json_last_error_msg() )
+			);
 			return false;
 		}
 

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -81,6 +81,9 @@ class AdminMenu {
 	public function enqueue_admin_assets( string $hook ): void {
 		$version = Helper::get_asset_version();
 
+		// Inline config blobs below print at admin_print_footer_scripts priority 5
+		// so they land in the document before wp_enqueue_script_module's deferred
+		// module tag executes and reads window.zwTTVGPT*.
 		// Enqueue audit assets on audit page.
 		if ( 'tools_page_zw-ttvgpt-audit' === $hook ) {
 			wp_enqueue_style( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.css', array(), $version );

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -27,6 +27,14 @@ use ZW_TTVGPT_Core\SettingsManager;
  */
 class AdminMenu {
 	/**
+	 * Cached SettingsPage instance so menu registration and asset enqueuing share state.
+	 *
+	 * @since 1.0.0
+	 * @var SettingsPage
+	 */
+	private readonly SettingsPage $settings_page;
+
+	/**
 	 * Initializes the admin menu and registers WordPress hooks.
 	 *
 	 * @since 1.0.0
@@ -34,6 +42,8 @@ class AdminMenu {
 	 * @param Logger $logger Logger instance for debugging.
 	 */
 	public function __construct( private readonly Logger $logger ) {
+		$this->settings_page = new SettingsPage( $this->logger );
+
 		add_action( 'admin_menu', $this->add_admin_menu( ... ) );
 		add_action( 'admin_enqueue_scripts', $this->enqueue_admin_assets( ... ) );
 	}
@@ -49,7 +59,7 @@ class AdminMenu {
 			__( 'Tekst TV GPT', 'zw-ttvgpt' ),
 			Constants::REQUIRED_CAPABILITY,
 			Constants::SETTINGS_PAGE_SLUG,
-			array( new SettingsPage( $this->logger ), 'render' )
+			array( $this->settings_page, 'render' )
 		);
 
 		add_management_page(
@@ -71,9 +81,33 @@ class AdminMenu {
 	public function enqueue_admin_assets( string $hook ): void {
 		$version = Helper::get_asset_version();
 
-		// Enqueue audit CSS on audit page.
+		// Enqueue audit assets on audit page.
 		if ( 'tools_page_zw-ttvgpt-audit' === $hook ) {
 			wp_enqueue_style( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.css', array(), $version );
+
+			$audit_config = array( 'baseUrl' => admin_url( 'tools.php' ) );
+			add_action(
+				'admin_print_footer_scripts',
+				static function () use ( $audit_config ): void {
+					wp_print_inline_script_tag( 'window.zwTTVGPTAudit = ' . wp_json_encode( $audit_config ) . ';' );
+				},
+				5
+			);
+			wp_enqueue_script_module( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.js', array(), $version );
+			return;
+		}
+
+		// Enqueue settings JS on the settings page.
+		if ( 'settings_page_' . Constants::SETTINGS_PAGE_SLUG === $hook ) {
+			$settings_config = $this->settings_page->get_legacy_model_toggle_config();
+			add_action(
+				'admin_print_footer_scripts',
+				static function () use ( $settings_config ): void {
+					wp_print_inline_script_tag( 'window.zwTTVGPTSettings = ' . wp_json_encode( $settings_config ) . ';' );
+				},
+				5
+			);
+			wp_enqueue_script_module( 'zw-ttvgpt-settings', ZW_TTVGPT_URL . 'assets/settings.js', array(), $version );
 			return;
 		}
 

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -18,9 +18,7 @@ use ZW_TTVGPT_Core\Logger;
 use ZW_TTVGPT_Core\SettingsManager;
 
 /**
- * Admin Menu class.
- *
- * Handles WordPress admin menu registration and asset loading.
+ * Registers plugin admin pages and admin-only assets.
  *
  * @package ZW_TTVGPT
  * @since   1.0.0
@@ -49,7 +47,7 @@ class AdminMenu {
 	}
 
 	/**
-	 * Adds plugin settings page to WordPress admin menu.
+	 * Registers the settings and audit admin pages.
 	 *
 	 * @since 1.0.0
 	 */
@@ -148,13 +146,9 @@ class AdminMenu {
 	}
 
 	/**
-	 * Schedules an inline window.<global_name> = <json>; tag at footer priority 5.
+	 * Schedules window config before module execution.
 	 *
-	 * Encodes upfront so a wp_json_encode failure logs and aborts instead of
-	 * emitting `window.X = ;` — a SyntaxError that silently breaks the matching
-	 * ES module on the page. Returns a boolean so the caller can skip the
-	 * matching wp_enqueue_script_module() and avoid loading a module against
-	 * config that was never printed.
+	 * Pre-encodes JSON so callers can skip the module when config cannot be printed.
 	 *
 	 * @since 1.0.0
 	 *

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -81,11 +81,7 @@ class AdminMenu {
 	public function enqueue_admin_assets( string $hook ): void {
 		$version = Helper::get_asset_version();
 
-		// Inline config blobs below print at admin_print_footer_scripts priority 5
-		// so they land in the document before wp_enqueue_script_module's deferred
-		// module tag executes and reads window.zwTTVGPT*. If encoding fails, we
-		// skip the enqueue so the module isn't loaded against missing config —
-		// the module would `console.warn` and the page would silently degrade.
+		// Inline config prints before the deferred module tags read window.zwTTVGPT*.
 		if ( 'tools_page_zw-ttvgpt-audit' === $hook ) {
 			wp_enqueue_style( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.css', array(), $version );
 
@@ -146,8 +142,6 @@ class AdminMenu {
 			),
 		);
 
-		// ES module (WordPress 6.5+) is enqueued only if its inline config encoded
-		// successfully; otherwise we'd ship a module without the data it expects.
 		if ( $this->print_inline_config( 'zwTTVGPT', $inline_data ) ) {
 			wp_enqueue_script_module( 'zw-ttvgpt-admin', ZW_TTVGPT_URL . 'assets/admin.js', array(), $version );
 		}

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -83,24 +83,25 @@ class AdminMenu {
 
 		// Inline config blobs below print at admin_print_footer_scripts priority 5
 		// so they land in the document before wp_enqueue_script_module's deferred
-		// module tag executes and reads window.zwTTVGPT*.
-		// Enqueue audit assets on audit page.
+		// module tag executes and reads window.zwTTVGPT*. If encoding fails, we
+		// skip the enqueue so the module isn't loaded against missing config —
+		// the module would `console.warn` and the page would silently degrade.
 		if ( 'tools_page_zw-ttvgpt-audit' === $hook ) {
 			wp_enqueue_style( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.css', array(), $version );
 
-			$this->print_inline_config( 'zwTTVGPTAudit', array( 'baseUrl' => admin_url( 'tools.php' ) ) );
-			wp_enqueue_script_module( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.js', array(), $version );
+			if ( $this->print_inline_config( 'zwTTVGPTAudit', array( 'baseUrl' => admin_url( 'tools.php' ) ) ) ) {
+				wp_enqueue_script_module( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.js', array(), $version );
+			}
 			return;
 		}
 
-		// Enqueue settings JS on the settings page.
 		if ( 'settings_page_' . Constants::SETTINGS_PAGE_SLUG === $hook ) {
-			$this->print_inline_config( 'zwTTVGPTSettings', $this->settings_page->get_legacy_model_toggle_config() );
-			wp_enqueue_script_module( 'zw-ttvgpt-settings', ZW_TTVGPT_URL . 'assets/settings.js', array(), $version );
+			if ( $this->print_inline_config( 'zwTTVGPTSettings', $this->settings_page->get_legacy_model_toggle_config() ) ) {
+				wp_enqueue_script_module( 'zw-ttvgpt-settings', ZW_TTVGPT_URL . 'assets/settings.js', array(), $version );
+			}
 			return;
 		}
 
-		// Enqueue admin assets on post edit screens.
 		if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
 			return;
 		}
@@ -110,7 +111,6 @@ class AdminMenu {
 			return;
 		}
 
-		// Enqueue CSS.
 		wp_enqueue_style( 'zw-ttvgpt-admin', ZW_TTVGPT_URL . 'assets/admin.css', array(), $version );
 
 		// Inline script data before module loads (wp_enqueue_script_module doesn't support wp_localize_script).
@@ -146,11 +146,11 @@ class AdminMenu {
 			),
 		);
 
-		// Print inline config data before module loads.
-		$this->print_inline_config( 'zwTTVGPT', $inline_data );
-
-		// Enqueue ES module (WordPress 6.5+).
-		wp_enqueue_script_module( 'zw-ttvgpt-admin', ZW_TTVGPT_URL . 'assets/admin.js', array(), $version );
+		// ES module (WordPress 6.5+) is enqueued only if its inline config encoded
+		// successfully; otherwise we'd ship a module without the data it expects.
+		if ( $this->print_inline_config( 'zwTTVGPT', $inline_data ) ) {
+			wp_enqueue_script_module( 'zw-ttvgpt-admin', ZW_TTVGPT_URL . 'assets/admin.js', array(), $version );
+		}
 	}
 
 	/**
@@ -158,20 +158,23 @@ class AdminMenu {
 	 *
 	 * Encodes upfront so a wp_json_encode failure logs and aborts instead of
 	 * emitting `window.X = ;` — a SyntaxError that silently breaks the matching
-	 * ES module on the page.
+	 * ES module on the page. Returns a boolean so the caller can skip the
+	 * matching wp_enqueue_script_module() and avoid loading a module against
+	 * config that was never printed.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $global_name Bare window property name (without `window.` prefix).
 	 * @param array  $config      Configuration to expose to the module.
+	 * @return bool True when the inline tag was scheduled; false when encoding failed.
 	 *
 	 * @phpstan-param array<string, mixed> $config
 	 */
-	private function print_inline_config( string $global_name, array $config ): void {
+	private function print_inline_config( string $global_name, array $config ): bool {
 		$json = wp_json_encode( $config );
 		if ( false === $json ) {
 			$this->logger->error( sprintf( 'Failed to encode inline config for window.%s', $global_name ) );
-			return;
+			return false;
 		}
 
 		add_action(
@@ -181,5 +184,6 @@ class AdminMenu {
 			},
 			5
 		);
+		return true;
 	}
 }

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -25,9 +25,8 @@ use ZW_TTVGPT_Core\SettingsManager;
  */
 class AdminMenu {
 	/**
-	 * Cached SettingsPage instance so menu registration and asset enqueuing share state.
+	 * Cached so add_admin_menu() and enqueue_admin_assets() use the same instance.
 	 *
-	 * @since 1.0.0
 	 * @var SettingsPage
 	 */
 	private readonly SettingsPage $settings_page;
@@ -146,15 +145,10 @@ class AdminMenu {
 	}
 
 	/**
-	 * Schedules window config before module execution.
-	 *
-	 * Pre-encodes JSON so callers can skip the module when config cannot be printed.
-	 *
-	 * @since 1.0.0
+	 * Pre-encodes JSON so callers can skip enqueueing the module when encoding fails.
 	 *
 	 * @param string $global_name Bare window property name (without `window.` prefix).
 	 * @param array  $config      Configuration to expose to the module.
-	 * @return bool True when the inline tag was scheduled; false when encoding failed.
 	 *
 	 * @phpstan-param array<string, mixed> $config
 	 */

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -88,28 +88,14 @@ class AdminMenu {
 		if ( 'tools_page_zw-ttvgpt-audit' === $hook ) {
 			wp_enqueue_style( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.css', array(), $version );
 
-			$audit_config = array( 'baseUrl' => admin_url( 'tools.php' ) );
-			add_action(
-				'admin_print_footer_scripts',
-				static function () use ( $audit_config ): void {
-					wp_print_inline_script_tag( 'window.zwTTVGPTAudit = ' . wp_json_encode( $audit_config ) . ';' );
-				},
-				5
-			);
+			$this->print_inline_config( 'zwTTVGPTAudit', array( 'baseUrl' => admin_url( 'tools.php' ) ) );
 			wp_enqueue_script_module( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.js', array(), $version );
 			return;
 		}
 
 		// Enqueue settings JS on the settings page.
 		if ( 'settings_page_' . Constants::SETTINGS_PAGE_SLUG === $hook ) {
-			$settings_config = $this->settings_page->get_legacy_model_toggle_config();
-			add_action(
-				'admin_print_footer_scripts',
-				static function () use ( $settings_config ): void {
-					wp_print_inline_script_tag( 'window.zwTTVGPTSettings = ' . wp_json_encode( $settings_config ) . ';' );
-				},
-				5
-			);
+			$this->print_inline_config( 'zwTTVGPTSettings', $this->settings_page->get_legacy_model_toggle_config() );
 			wp_enqueue_script_module( 'zw-ttvgpt-settings', ZW_TTVGPT_URL . 'assets/settings.js', array(), $version );
 			return;
 		}
@@ -161,15 +147,39 @@ class AdminMenu {
 		);
 
 		// Print inline config data before module loads.
-		add_action(
-			'admin_print_footer_scripts',
-			static function () use ( $inline_data ): void {
-				wp_print_inline_script_tag( 'window.zwTTVGPT = ' . wp_json_encode( $inline_data ) . ';' );
-			},
-			5
-		);
+		$this->print_inline_config( 'zwTTVGPT', $inline_data );
 
 		// Enqueue ES module (WordPress 6.5+).
 		wp_enqueue_script_module( 'zw-ttvgpt-admin', ZW_TTVGPT_URL . 'assets/admin.js', array(), $version );
+	}
+
+	/**
+	 * Schedules an inline window.<global_name> = <json>; tag at footer priority 5.
+	 *
+	 * Encodes upfront so a wp_json_encode failure logs and aborts instead of
+	 * emitting `window.X = ;` — a SyntaxError that silently breaks the matching
+	 * ES module on the page.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $global_name Bare window property name (without `window.` prefix).
+	 * @param array  $config      Configuration to expose to the module.
+	 *
+	 * @phpstan-param array<string, mixed> $config
+	 */
+	private function print_inline_config( string $global_name, array $config ): void {
+		$json = wp_json_encode( $config );
+		if ( false === $json ) {
+			$this->logger->error( sprintf( 'Failed to encode inline config for window.%s', $global_name ) );
+			return;
+		}
+
+		add_action(
+			'admin_print_footer_scripts',
+			static function () use ( $global_name, $json ): void {
+				wp_print_inline_script_tag( sprintf( 'window.%s = %s;', $global_name, $json ) );
+			},
+			5
+		);
 	}
 }

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -72,8 +72,10 @@ class AuditPage {
 	private const int POSTS_PER_PAGE = 50;
 
 	/**
-	 * Allowed HTML for rendered diff markup. The renderer only ever emits
-	 * span.zw-diff-added / span.zw-diff-removed, so the allowlist is tight.
+	 * Allowed HTML for rendered diff markup. Currently emits via
+	 * AuditHelper::generate_word_diff, which only produces span.zw-diff-added
+	 * and span.zw-diff-removed — widen this allowlist only if that helper
+	 * starts emitting new tags, and update DIFF_ALLOWED_CLASSES in lockstep.
 	 *
 	 * @since 1.0.0
 	 * @var array<string, array<string, bool>>
@@ -94,7 +96,9 @@ class AuditPage {
 	 * @param array $items          Items to paginate (any indexed list).
 	 * @param int   $requested_page Page number the caller asked for.
 	 * @param int   $per_page       Page size; values < 1 are treated as "no slicing wanted".
-	 * @return array Pagination outcome including the slice, the clamped page, total pages, and total count.
+	 * @return array{slice: array, paged: int, total_pages: int, total: int} Pagination outcome:
+	 *                  the slice for the requested page, the clamped page number, total page
+	 *                  count, and total item count before slicing.
 	 *
 	 * @phpstan-template T
 	 * @phpstan-param array<int, T> $items
@@ -137,6 +141,14 @@ class AuditPage {
 	 * tolerates the variations wp_kses leaves intact: single/double quotes,
 	 * uppercase tag/attribute names, whitespace padding inside the value.
 	 *
+	 * The regex is iterated until the output is stable. A single pass uses
+	 * non-greedy `(.*?)` and so binds the outer disallowed span to the FIRST
+	 * `</span>` it sees — for nested disallowed spans like
+	 * `<span class="a"><span class="b">x</span></span>` that leaves the inner
+	 * span as a top-level survivor. Re-running peels one level per pass.
+	 * Every replacement strictly shrinks the string, so the loop terminates;
+	 * the iteration cap is a defensive bound against pathological input.
+	 *
 	 * Centralizing here keeps the modal render path and the regression
 	 * tests in AuditPageDiffAllowlistTest exercising the same sanitizer —
 	 * removing either pass fails those tests, not just the constant lock-in.
@@ -150,13 +162,18 @@ class AuditPage {
 		$kses_out = wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
 
 		$class_pattern = implode( '|', array_map( 'preg_quote', self::DIFF_ALLOWED_CLASSES ) );
-		$result        = preg_replace(
-			'#<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>(.*?)</(?i:span)>#s',
-			'$2',
-			$kses_out
-		);
+		$pattern       = '#<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>(.*?)</(?i:span)>#s';
 
-		return is_string( $result ) ? $result : $kses_out;
+		$current = $kses_out;
+		for ( $i = 0; $i < 20; $i++ ) {
+			$next = preg_replace( $pattern, '$2', $current );
+			if ( ! is_string( $next ) || $next === $current ) {
+				return $current;
+			}
+			$current = $next;
+		}
+
+		return $current;
 	}
 
 	/**

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -46,8 +46,11 @@ class AuditPage {
 		if ( null === $year && null === $month && isset( $_GET['m'] ) ) {
 			$raw = sanitize_text_field( wp_unslash( $_GET['m'] ) );
 			if ( '' !== $raw && '0' !== $raw && preg_match( '/^\d{6}$/', $raw ) ) {
-				$year  = (int) substr( $raw, 0, 4 );
-				$month = (int) substr( $raw, 4, 2 );
+				$parsed_month = (int) substr( $raw, 4, 2 );
+				if ( $parsed_month >= 1 && $parsed_month <= 12 ) {
+					$year  = (int) substr( $raw, 0, 4 );
+					$month = $parsed_month;
+				}
 			}
 		}
 
@@ -130,6 +133,36 @@ class AuditPage {
 	private const array DIFF_ALLOWED_CLASSES = array( 'zw-diff-added', 'zw-diff-removed' );
 
 	/**
+	 * Reports sanitizer fail-closed paths without logging diff content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $reason        Stable reason code.
+	 * @param string $error_message Optional lower-level error message.
+	 */
+	private static function report_diff_sanitizer_failure( string $reason, string $error_message = '' ): void {
+		if ( function_exists( 'do_action' ) ) {
+			do_action( 'zw_ttvgpt_diff_sanitizer_failed', $reason, $error_message );
+		}
+	}
+
+	/**
+	 * Runs wp_kses across the plugin/filter boundary.
+	 *
+	 * WordPress documents wp_kses() as returning string, but the pre_kses filter
+	 * can return arbitrary values. Keep the boundary typed as mixed so the caller
+	 * can guard before passing the value into PCRE functions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $diff_html Raw diff HTML.
+	 * @return mixed Filtered diff output.
+	 */
+	private static function kses_diff_html( string $diff_html ): mixed {
+		return wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
+	}
+
+	/**
 	 * Sanitizes diff markup for display in the audit modal.
 	 *
 	 * Note: `wp_kses` with `['span' => ['class' => true]]` strips disallowed
@@ -165,9 +198,19 @@ class AuditPage {
 	 * @return string HTML safe to echo into the audit modal panes.
 	 */
 	public static function sanitize_diff_panel( string $diff_html ): string {
-		$kses_out = wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
+		$kses_out = self::kses_diff_html( $diff_html );
+		if ( ! is_string( $kses_out ) ) {
+			self::report_diff_sanitizer_failure( 'wp_kses_non_string' );
+			return wp_strip_all_tags( $diff_html );
+		}
 
-		$class_pattern = implode( '|', array_map( 'preg_quote', self::DIFF_ALLOWED_CLASSES ) );
+		$class_pattern = implode(
+			'|',
+			array_map(
+				static fn ( string $class_name ): string => preg_quote( $class_name, '#' ),
+				self::DIFF_ALLOWED_CLASSES
+			)
+		);
 		// Shared predicate: an opening <span...> whose class is NOT in the
 		// allowlist. The paired pattern below requires a matching </span>;
 		// the open-only pattern reuses the same predicate to catch orphan
@@ -181,16 +224,31 @@ class AuditPage {
 		// final stability check to confirm no further changes. Counted with
 		// the same case-insensitive match the regex above uses so the bound
 		// never undershoots on non-normalized input.
-		$max_iterations = (int) preg_match_all( '/<span\b/i', $kses_out ) + 1;
+		$span_count = preg_match_all( '/<span\b/i', $kses_out );
+		if ( false === $span_count ) {
+			self::report_diff_sanitizer_failure( 'span_count_regex_failed', preg_last_error_msg() );
+			return wp_strip_all_tags( $kses_out );
+		}
+		$max_iterations = $span_count + 1;
 
 		$current = $kses_out;
 		for ( $i = 0; $i < $max_iterations; $i++ ) {
 			$next = preg_replace( $paired_pattern, '$2', $current );
-			if ( ! is_string( $next ) || $next === $current ) {
+			if ( null === $next ) {
+				self::report_diff_sanitizer_failure( 'paired_regex_failed', preg_last_error_msg() );
+				return wp_strip_all_tags( $current );
+			}
+			if ( $next === $current ) {
 				// Stable, but the paired regex can only strip balanced
 				// disallowed spans. If a disallowed open survived without a
 				// matching close, fail closed rather than echo live markup.
-				if ( 1 === preg_match( $open_pattern, $current ) ) {
+				$open_match = preg_match( $open_pattern, $current );
+				if ( false === $open_match ) {
+					self::report_diff_sanitizer_failure( 'open_regex_failed', preg_last_error_msg() );
+					return wp_strip_all_tags( $current );
+				}
+				if ( 1 === $open_match ) {
+					self::report_diff_sanitizer_failure( 'orphan_disallowed_span' );
 					return wp_strip_all_tags( $current );
 				}
 				return $current;
@@ -198,6 +256,7 @@ class AuditPage {
 			$current = $next;
 		}
 
+		self::report_diff_sanitizer_failure( 'iteration_cap_exceeded' );
 		return wp_strip_all_tags( $current );
 	}
 

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -116,12 +116,30 @@ class AuditPage {
 	}
 
 	/**
+	 * Class values that survive the diff sanitizer. Anything else is stripped
+	 * to inert text. Mirrors the two class names AuditHelper::generate_word_diff
+	 * emits via str_replace, so widening either end requires touching both.
+	 *
+	 * @since 1.0.0
+	 * @var array<int, string>
+	 */
+	private const array DIFF_ALLOWED_CLASSES = array( 'zw-diff-added', 'zw-diff-removed' );
+
+	/**
 	 * Sanitizes diff markup for display in the audit modal.
 	 *
-	 * Centralizes the wp_kses + DIFF_ALLOWED_TAGS application so the modal
-	 * render path and the regression test in AuditPageDiffAllowlistTest
-	 * exercise the same sanitizer. Removing this helper (or weakening it)
-	 * fails the malicious-content tests, not just the constant lock-in.
+	 * Note: `wp_kses` with `['span' => ['class' => true]]` strips disallowed
+	 * tags but does NOT validate the class attribute value — any class string
+	 * passes. That breaks the "safe to echo" contract on raw input like
+	 * `<span class="evil">x</span>`. We therefore run a second pass that
+	 * drops every <span> whose class is not exactly zw-diff-added or
+	 * zw-diff-removed, keeping its inner content as text. The pattern
+	 * tolerates the variations wp_kses leaves intact: single/double quotes,
+	 * uppercase tag/attribute names, whitespace padding inside the value.
+	 *
+	 * Centralizing here keeps the modal render path and the regression
+	 * tests in AuditPageDiffAllowlistTest exercising the same sanitizer —
+	 * removing either pass fails those tests, not just the constant lock-in.
 	 *
 	 * @since 1.0.0
 	 *
@@ -129,7 +147,16 @@ class AuditPage {
 	 * @return string HTML safe to echo into the audit modal panes.
 	 */
 	public static function sanitize_diff_panel( string $diff_html ): string {
-		return wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
+		$kses_out = wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
+
+		$class_pattern = implode( '|', array_map( 'preg_quote', self::DIFF_ALLOWED_CLASSES ) );
+		$result        = preg_replace(
+			'#<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>(.*?)</(?i:span)>#s',
+			'$2',
+			$kses_out
+		);
+
+		return is_string( $result ) ? $result : $kses_out;
 	}
 
 	/**

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -171,8 +171,10 @@ class AuditPage {
 		$pattern       = '#<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>(.*?)</(?i:span)>#s';
 
 		// Tight upper bound: one iteration per span in the input, plus one
-		// final stability check to confirm no further changes.
-		$max_iterations = substr_count( $kses_out, '<span' ) + 1;
+		// final stability check to confirm no further changes. Counted with
+		// the same case-insensitive match the regex above uses so the bound
+		// never undershoots on non-normalized input.
+		$max_iterations = (int) preg_match_all( '/<span\b/i', $kses_out ) + 1;
 
 		$current = $kses_out;
 		for ( $i = 0; $i < $max_iterations; $i++ ) {

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -47,7 +47,9 @@ class AuditPage {
 	}
 
 	/**
-	 * Posts shown per page on the audit overview.
+	 * Posts per page on the audit overview. Sized to show a meaningful slice
+	 * of a typical month without blowing up render time on large months
+	 * (the page renders a hidden modal per row, so the cost is non-trivial).
 	 *
 	 * @since 1.0.0
 	 * @var int
@@ -328,7 +330,7 @@ class AuditPage {
 					);
 					?>
 				</span>
-				<?php $this->render_pagination_links( $paged, $total_pages ); ?>
+				<?php $this->render_pagination_links( $paged, $total_pages, $year, $month, $status_filter, $change_filter ); ?>
 			</div>
 			<br class="clear">
 		</div>
@@ -338,19 +340,44 @@ class AuditPage {
 	/**
 	 * Renders WordPress-style pagination links preserving current filters.
 	 *
+	 * Builds the base URL from a known allowlist of args (the audit page slug
+	 * plus active filters) so unrelated query parameters present in
+	 * REQUEST_URI — e.g. _wp_http_referer, settings-updated, filter_action —
+	 * do not leak into pagination hrefs.
+	 *
 	 * @since 1.0.0
 	 *
-	 * @param int $paged       Current page (1-indexed).
-	 * @param int $total_pages Total number of pages.
+	 * @param int    $paged         Current page (1-indexed).
+	 * @param int    $total_pages   Total number of pages.
+	 * @param int    $year          Active year filter.
+	 * @param int    $month         Active month filter.
+	 * @param string $status_filter Active status filter (empty when none).
+	 * @param string $change_filter Active change-percentage filter (empty when none).
 	 */
-	private function render_pagination_links( int $paged, int $total_pages ): void {
+	private function render_pagination_links(
+		int $paged,
+		int $total_pages,
+		int $year,
+		int $month,
+		string $status_filter,
+		string $change_filter
+	): void {
 		if ( $total_pages < 2 ) {
 			return;
 		}
 
+		$base_args = array(
+			'page'   => 'zw-ttvgpt-audit',
+			'year'   => $year,
+			'month'  => $month,
+			'status' => '' !== $status_filter ? $status_filter : false,
+			'change' => '' !== $change_filter ? $change_filter : false,
+			'paged'  => '%#%',
+		);
+
 		$links = paginate_links(
 			array(
-				'base'      => add_query_arg( 'paged', '%#%' ),
+				'base'      => add_query_arg( $base_args, admin_url( 'tools.php' ) ),
 				'format'    => '',
 				'prev_text' => __( '&laquo;', 'zw-ttvgpt' ),
 				'next_text' => __( '&raquo;', 'zw-ttvgpt' ),

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -83,6 +83,56 @@ class AuditPage {
 	);
 
 	/**
+	 * Slices a list into a single page and returns clamped pagination state.
+	 *
+	 * Requested pages outside [1, total_pages] are clamped to the closest
+	 * valid page so an out-of-range ?paged= still renders the table instead
+	 * of a blank slice. Empty input returns paged=1, total_pages=0.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $items          Items to paginate (any indexed list).
+	 * @param int   $requested_page Page number the caller asked for.
+	 * @param int   $per_page       Page size; values < 1 are treated as "no slicing wanted".
+	 * @return array Pagination outcome including the slice, the clamped page, total pages, and total count.
+	 *
+	 * @phpstan-template T
+	 * @phpstan-param array<int, T> $items
+	 * @phpstan-return array{slice: array<int, T>, paged: int, total_pages: int, total: int}
+	 */
+	public static function paginate( array $items, int $requested_page, int $per_page ): array {
+		$total       = count( $items );
+		$total_pages = $per_page > 0 ? (int) ceil( $total / $per_page ) : 0;
+		$paged       = $total_pages > 0 ? min( max( 1, $requested_page ), $total_pages ) : 1;
+		$offset      = ( $paged - 1 ) * max( 0, $per_page );
+		$slice       = $per_page > 0 ? array_slice( $items, $offset, $per_page ) : array();
+
+		return array(
+			'slice'       => $slice,
+			'paged'       => $paged,
+			'total_pages' => $total_pages,
+			'total'       => $total,
+		);
+	}
+
+	/**
+	 * Sanitizes diff markup for display in the audit modal.
+	 *
+	 * Centralizes the wp_kses + DIFF_ALLOWED_TAGS application so the modal
+	 * render path and the regression test in AuditPageDiffAllowlistTest
+	 * exercise the same sanitizer. Removing this helper (or weakening it)
+	 * fails the malicious-content tests, not just the constant lock-in.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $diff_html Raw diff HTML emitted by AuditHelper::generate_word_diff.
+	 * @return string HTML safe to echo into the audit modal panes.
+	 */
+	public static function sanitize_diff_panel( string $diff_html ): string {
+		return wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
+	}
+
+	/**
 	 * Renders the audit analysis page.
 	 *
 	 * @since 1.0.0
@@ -155,11 +205,11 @@ class AuditPage {
 		$available_months = AuditHelper::get_months();
 
 		// Slice filtered results for the requested page.
-		$total_filtered = count( $categorized_posts );
-		$total_pages    = (int) ceil( $total_filtered / self::POSTS_PER_PAGE );
-		$paged          = $total_pages > 0 ? min( $paged, $total_pages ) : 1;
-		$page_offset    = ( $paged - 1 ) * self::POSTS_PER_PAGE;
-		$page_slice     = array_slice( $categorized_posts, $page_offset, self::POSTS_PER_PAGE );
+		$pagination     = self::paginate( $categorized_posts, $paged, self::POSTS_PER_PAGE );
+		$page_slice     = $pagination['slice'];
+		$paged          = $pagination['paged'];
+		$total_pages    = $pagination['total_pages'];
+		$total_filtered = $pagination['total'];
 
 		// Stylesheet is enqueued by AdminMenu on the audit page hook.
 		add_thickbox();
@@ -595,7 +645,10 @@ class AuditPage {
 								</div>
 								<div class="inside">
 									<div style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
-										<?php echo wp_kses( $diff['before'], self::DIFF_ALLOWED_TAGS ); ?>
+										<?php
+										// sanitize_diff_panel applies wp_kses with DIFF_ALLOWED_TAGS.
+										echo self::sanitize_diff_panel( $diff['before'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+										?>
 									</div>
 								</div>
 							</div>
@@ -606,7 +659,10 @@ class AuditPage {
 								</div>
 								<div class="inside">
 									<div style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
-										<?php echo wp_kses( $diff['after'], self::DIFF_ALLOWED_TAGS ); ?>
+										<?php
+										// sanitize_diff_panel applies wp_kses with DIFF_ALLOWED_TAGS.
+										echo self::sanitize_diff_panel( $diff['after'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+										?>
 									</div>
 								</div>
 							</div>

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -141,13 +141,19 @@ class AuditPage {
 	 * tolerates the variations wp_kses leaves intact: single/double quotes,
 	 * uppercase tag/attribute names, whitespace padding inside the value.
 	 *
-	 * The regex is iterated until the output is stable. A single pass uses
-	 * non-greedy `(.*?)` and so binds the outer disallowed span to the FIRST
-	 * `</span>` it sees — for nested disallowed spans like
-	 * `<span class="a"><span class="b">x</span></span>` that leaves the inner
-	 * span as a top-level survivor. Re-running peels one level per pass.
-	 * Every replacement strictly shrinks the string, so the loop terminates;
-	 * the iteration cap is a defensive bound against pathological input.
+	 * The regex is iterated because a single pass uses non-greedy `(.*?)`
+	 * and binds the outer disallowed span to the FIRST `</span>` it sees —
+	 * for nested disallowed spans like `<span class="a"><span class="b">x
+	 * </span></span>` that leaves the inner span as a top-level survivor.
+	 * Re-running peels one level per pass.
+	 *
+	 * Iterations are bounded by the count of `<span` markers in the
+	 * kses-normalized input: each pass removes at least one disallowed
+	 * span (otherwise the stability check exits), and the substitution is
+	 * `$2` — content between the matched open/close pair — so new `<span`
+	 * markers can never be introduced. If the bound is somehow exceeded we
+	 * MUST NOT return the partially-stripped string (it can still contain
+	 * a live disallowed span); fail closed by stripping all remaining tags.
 	 *
 	 * Centralizing here keeps the modal render path and the regression
 	 * tests in AuditPageDiffAllowlistTest exercising the same sanitizer —
@@ -164,8 +170,12 @@ class AuditPage {
 		$class_pattern = implode( '|', array_map( 'preg_quote', self::DIFF_ALLOWED_CLASSES ) );
 		$pattern       = '#<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>(.*?)</(?i:span)>#s';
 
+		// Tight upper bound: one iteration per span in the input, plus one
+		// final stability check to confirm no further changes.
+		$max_iterations = substr_count( $kses_out, '<span' ) + 1;
+
 		$current = $kses_out;
-		for ( $i = 0; $i < 20; $i++ ) {
+		for ( $i = 0; $i < $max_iterations; $i++ ) {
 			$next = preg_replace( $pattern, '$2', $current );
 			if ( ! is_string( $next ) || $next === $current ) {
 				return $current;
@@ -173,7 +183,7 @@ class AuditPage {
 			$current = $next;
 		}
 
-		return $current;
+		return wp_strip_all_tags( $current );
 	}
 
 	/**

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -59,20 +59,12 @@ class AuditPage {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
-	/**
-	 * Posts per page on the audit overview.
-	 *
-	 * The page renders a hidden modal per row, so large pages are expensive.
-	 *
-	 * @since 1.0.0
-	 * @var int
-	 */
+	/** The page emits a hidden modal per row, so large pages are expensive. */
 	private const int POSTS_PER_PAGE = 50;
 
 	/**
-	 * Allowed tags for diff output; keep in sync with generate_word_diff() and DIFF_ALLOWED_CLASSES.
+	 * Keep in sync with generate_word_diff() and DIFF_ALLOWED_CLASSES.
 	 *
-	 * @since 1.0.0
 	 * @var array<string, array<string, bool>>
 	 */
 	private const array DIFF_ALLOWED_TAGS = array(
@@ -80,20 +72,11 @@ class AuditPage {
 	);
 
 	/**
-	 * Slices a list into a single page and returns clamped pagination state.
+	 * Clamps out-of-range pages so a stale ?paged= still renders the table.
 	 *
-	 * Requested pages outside [1, total_pages] are clamped to the closest
-	 * valid page so an out-of-range ?paged= still renders the table instead
-	 * of a blank slice. Empty input returns paged=1, total_pages=0.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $items          Items to paginate (any indexed list).
-	 * @param int   $requested_page Page number the caller asked for.
-	 * @param int   $per_page       Page size; values < 1 are treated as "no slicing wanted".
-	 * @return array{slice: array, paged: int, total_pages: int, total: int} Pagination outcome:
-	 *                  the slice for the requested page, the clamped page number, total page
-	 *                  count, and total item count before slicing.
+	 * @param array $items          Items to slice.
+	 * @param int   $requested_page Requested page (1-indexed; clamped to a valid page).
+	 * @param int   $per_page       Page size; values < 1 are treated as "no slicing".
 	 *
 	 * @phpstan-template T
 	 * @phpstan-param array<int, T> $items
@@ -115,17 +98,14 @@ class AuditPage {
 	}
 
 	/**
-	 * Allowed diff class values emitted by AuditHelper::generate_word_diff().
+	 * Diff class names emitted by AuditHelper::generate_word_diff().
 	 *
-	 * @since 1.0.0
 	 * @var array<int, string>
 	 */
 	private const array DIFF_ALLOWED_CLASSES = array( 'zw-diff-added', 'zw-diff-removed' );
 
 	/**
-	 * Fires zw_ttvgpt_diff_sanitizer_failed without logging diff content.
-	 *
-	 * @since 1.0.0
+	 * Reports a sanitizer failure without leaking diff content.
 	 *
 	 * @param string $reason        Stable reason code.
 	 * @param string $error_message Optional lower-level error message.
@@ -137,33 +117,24 @@ class AuditPage {
 	}
 
 	/**
-	 * Runs wp_kses across the plugin/filter boundary.
-	 *
-	 * WordPress documents wp_kses() as returning string, but the pre_kses filter
-	 * can return arbitrary values. Keep the boundary typed as mixed so the caller
-	 * can guard before passing the value into PCRE functions.
-	 *
-	 * @since 1.0.0
+	 * Runs wp_kses across the pre_kses filter, which can return arbitrary
+	 * values; the caller must guard before handing the result to PCRE.
 	 *
 	 * @param string $diff_html Raw diff HTML.
-	 * @return mixed Filtered diff output.
 	 */
 	private static function kses_diff_html( string $diff_html ): mixed {
 		return wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
 	}
 
 	/**
-	 * Sanitizes diff markup for display in the audit modal.
+	 * Sanitizes diff HTML for the audit modal.
 	 *
-	 * WordPress allows any class value when class is allowed in wp_kses(), so this
-	 * adds a second pass that keeps only the plugin's diff classes and converts
-	 * all other span markup to inert text. Malformed or untrusted output fails
-	 * closed by stripping all remaining tags.
-	 *
-	 * @since 1.0.0
+	 * Because wp_kses() accepts any class value when class is in the allowlist,
+	 * this adds a pass that keeps only the plugin's diff classes and converts
+	 * other span markup to inert text. Fails closed by stripping remaining tags
+	 * on any sign of malformed or untrusted output.
 	 *
 	 * @param string $diff_html Raw diff HTML emitted by AuditHelper::generate_word_diff.
-	 * @return string HTML safe to echo into the audit modal panes.
 	 */
 	public static function sanitize_diff_panel( string $diff_html ): string {
 		$kses_out = self::kses_diff_html( $diff_html );
@@ -172,18 +143,21 @@ class AuditPage {
 			return wp_strip_all_tags( $diff_html );
 		}
 
-		$class_pattern = implode(
-			'|',
-			array_map(
-				static fn ( string $class_name ): string => preg_quote( $class_name, '#' ),
-				self::DIFF_ALLOWED_CLASSES
-			)
-		);
-		// Shared predicate for disallowed span opens, reused for paired and
-		// orphan-span checks.
-		$disallowed_open = '<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>';
-		$paired_pattern  = '#' . $disallowed_open . '(.*?)</(?i:span)>#s';
-		$open_pattern    = '#' . $disallowed_open . '#';
+		// DIFF_ALLOWED_CLASSES is constant, so build the predicate once per process.
+		static $paired_pattern = null;
+		static $open_pattern   = null;
+		if ( null === $paired_pattern ) {
+			$class_pattern   = implode(
+				'|',
+				array_map(
+					static fn ( string $class_name ): string => preg_quote( $class_name, '#' ),
+					self::DIFF_ALLOWED_CLASSES
+				)
+			);
+			$disallowed_open = '<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>';
+			$paired_pattern  = '#' . $disallowed_open . '(.*?)</(?i:span)>#s';
+			$open_pattern    = '#' . $disallowed_open . '#';
+		}
 
 		// Bound iteration to the number of input spans, plus one stability check.
 		$span_count = preg_match_all( '/<span\b/i', $kses_out );
@@ -480,7 +454,18 @@ class AuditPage {
 					);
 					?>
 				</span>
-				<?php $this->render_pagination_links( $paged, $total_pages, $year, $month, $status_filter, $change_filter ); ?>
+				<?php
+				$this->render_pagination_links(
+					array(
+						'year'          => $year,
+						'month'         => $month,
+						'status_filter' => $status_filter,
+						'change_filter' => $change_filter,
+						'paged'         => $paged,
+					),
+					$total_pages
+				);
+				?>
 			</div>
 			<br class="clear">
 		</div>
@@ -488,40 +473,27 @@ class AuditPage {
 	}
 
 	/**
-	 * Renders WordPress-style pagination links preserving current filters.
-	 *
-	 * Builds the base URL from a known allowlist of args (the audit page slug
-	 * plus active filters) so unrelated query parameters present in
-	 * REQUEST_URI — e.g. _wp_http_referer, settings-updated, filter_action —
-	 * do not leak into pagination hrefs.
+	 * Renders pagination links from a known arg allowlist so unrelated REQUEST_URI
+	 * params (filter_action, _wp_http_referer, etc.) cannot leak into hrefs.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param int    $paged         Current page (1-indexed).
-	 * @param int    $total_pages   Total number of pages.
-	 * @param int    $year          Active year filter.
-	 * @param int    $month         Active month filter.
-	 * @param string $status_filter Active status filter (empty when none).
-	 * @param string $change_filter Active change-percentage filter (empty when none).
+	 * @param array $filters     Active filters; pass `paged` set to the clamped current page.
+	 * @param int   $total_pages Total number of pages.
+	 *
+	 * @phpstan-param FilterParams $filters
 	 */
-	private function render_pagination_links(
-		int $paged,
-		int $total_pages,
-		int $year,
-		int $month,
-		string $status_filter,
-		string $change_filter
-	): void {
+	private function render_pagination_links( array $filters, int $total_pages ): void {
 		if ( $total_pages < 2 ) {
 			return;
 		}
 
 		$base_args = array(
 			'page'   => 'zw-ttvgpt-audit',
-			'year'   => $year,
-			'month'  => $month,
-			'status' => '' !== $status_filter ? $status_filter : false,
-			'change' => '' !== $change_filter ? $change_filter : false,
+			'year'   => $filters['year'],
+			'month'  => $filters['month'],
+			'status' => '' !== $filters['status_filter'] ? $filters['status_filter'] : false,
+			'change' => '' !== $filters['change_filter'] ? $filters['change_filter'] : false,
 			'paged'  => '%#%',
 		);
 
@@ -532,7 +504,7 @@ class AuditPage {
 				'prev_text' => __( '&laquo;', 'zw-ttvgpt' ),
 				'next_text' => __( '&raquo;', 'zw-ttvgpt' ),
 				'total'     => $total_pages,
-				'current'   => $paged,
+				'current'   => $filters['paged'],
 				'type'      => 'plain',
 			)
 		);

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -16,9 +16,7 @@ use ZW_TTVGPT_Core\AuditHelper;
 use ZW_TTVGPT_Core\AuditStatus;
 
 /**
- * Audit Page class.
- *
- * Handles audit page rendering and analysis.
+ * Renders the audit tools page and diff review UI.
  *
  * @package ZW_TTVGPT
  * @since   1.0.0
@@ -39,10 +37,7 @@ class AuditPage {
 		$year  = isset( $_GET['year'] ) ? absint( $_GET['year'] ) : null;
 		$month = isset( $_GET['month'] ) ? absint( $_GET['month'] ) : null;
 
-		// Fallback for native form submit: the date <select> is named "m" and
-		// emits YYYYMM (e.g. "202604"). The audit.js module splits this into
-		// year+month before navigating, but if JS is unavailable (CSP, encode
-		// failure, etc.) the form posts ?m=YYYYMM directly. Parse it server-side.
+		// Fallback for native form submits when audit.js cannot split m=YYYYMM into year/month.
 		if ( null === $year && null === $month && isset( $_GET['m'] ) ) {
 			$raw = sanitize_text_field( wp_unslash( $_GET['m'] ) );
 			if ( '' !== $raw && '0' !== $raw && preg_match( '/^\d{6}$/', $raw ) ) {
@@ -75,10 +70,7 @@ class AuditPage {
 	private const int POSTS_PER_PAGE = 50;
 
 	/**
-	 * Allowed HTML for rendered diff markup. Currently emits via
-	 * AuditHelper::generate_word_diff, which only produces span.zw-diff-added
-	 * and span.zw-diff-removed — widen this allowlist only if that helper
-	 * starts emitting new tags, and update DIFF_ALLOWED_CLASSES in lockstep.
+	 * Allowed tags for diff output; keep in sync with generate_word_diff() and DIFF_ALLOWED_CLASSES.
 	 *
 	 * @since 1.0.0
 	 * @var array<string, array<string, bool>>
@@ -123,9 +115,7 @@ class AuditPage {
 	}
 
 	/**
-	 * Class values that survive the diff sanitizer. Anything else is stripped
-	 * to inert text. Mirrors the two class names AuditHelper::generate_word_diff
-	 * emits via str_replace, so widening either end requires touching both.
+	 * Allowed diff class values emitted by AuditHelper::generate_word_diff().
 	 *
 	 * @since 1.0.0
 	 * @var array<int, string>
@@ -133,7 +123,7 @@ class AuditPage {
 	private const array DIFF_ALLOWED_CLASSES = array( 'zw-diff-added', 'zw-diff-removed' );
 
 	/**
-	 * Reports sanitizer fail-closed paths without logging diff content.
+	 * Fires zw_ttvgpt_diff_sanitizer_failed without logging diff content.
 	 *
 	 * @since 1.0.0
 	 *
@@ -233,7 +223,7 @@ class AuditPage {
 	}
 
 	/**
-	 * Renders the audit analysis page.
+	 * Audit page callback for the Tools submenu.
 	 *
 	 * @since 1.0.0
 	 */
@@ -263,8 +253,6 @@ class AuditPage {
 			}
 		}
 
-		// Clean implementation - no benchmarking needed.
-
 		$posts  = AuditHelper::get_posts( $year, $month );
 		$counts = array(
 			AuditStatus::FullyHumanWritten->value  => 0,
@@ -282,10 +270,8 @@ class AuditPage {
 			$status   = $analysis['status'];
 			++$counts[ $status->value ];
 
-			// Apply status filter if set.
 			$status_match = empty( $status_filter ) || $status->value === $status_filter;
 
-			// Apply change filter if set (using match expression).
 			$change_match = match ( true ) {
 				empty( $change_filter )                       => true,
 				AuditStatus::AiWrittenEdited !== $status      => false,
@@ -304,7 +290,6 @@ class AuditPage {
 
 		$available_months = AuditHelper::get_months();
 
-		// Slice filtered results for the requested page.
 		$pagination     = self::paginate( $categorized_posts, $paged, self::POSTS_PER_PAGE );
 		$page_slice     = $pagination['slice'];
 		$paged          = $pagination['paged'];
@@ -723,7 +708,6 @@ class AuditPage {
 			</tfoot>
 		</table>
 		
-		<!-- ThickBox Inline Modals for Diff Display -->
 		<?php foreach ( $categorized_posts as $item ) : ?>
 			<?php if ( AuditStatus::AiWrittenEdited === $item['status'] ) : ?>
 				<?php

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -55,6 +55,17 @@ class AuditPage {
 	private const int POSTS_PER_PAGE = 50;
 
 	/**
+	 * Allowed HTML for rendered diff markup. The renderer only ever emits
+	 * span.zw-diff-added / span.zw-diff-removed, so the allowlist is tight.
+	 *
+	 * @since 1.0.0
+	 * @var array<string, array<string, bool>>
+	 */
+	private const array DIFF_ALLOWED_TAGS = array(
+		'span' => array( 'class' => true ),
+	);
+
+	/**
 	 * Renders the audit analysis page.
 	 *
 	 * @since 1.0.0
@@ -542,7 +553,7 @@ class AuditPage {
 								</div>
 								<div class="inside">
 									<div style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
-										<?php echo wp_kses_post( $diff['before'] ); ?>
+										<?php echo wp_kses( $diff['before'], self::DIFF_ALLOWED_TAGS ); ?>
 									</div>
 								</div>
 							</div>
@@ -553,7 +564,7 @@ class AuditPage {
 								</div>
 								<div class="inside">
 									<div style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
-										<?php echo wp_kses_post( $diff['after'] ); ?>
+										<?php echo wp_kses( $diff['after'], self::DIFF_ALLOWED_TAGS ); ?>
 									</div>
 								</div>
 							</div>
@@ -562,35 +573,6 @@ class AuditPage {
 				</div>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		
-		<script>
-		jQuery(function($) {
-			function applyFilters() {
-				var date = $('#filter-by-date').val();
-				var status = $('#filter-by-status').val();
-				var change = $('#filter-by-change').val();
-				var url = '<?php echo esc_js( admin_url( 'tools.php?page=zw-ttvgpt-audit' ) ); ?>';
-				var params = [];
-				
-				if (date && date !== '0') {
-					params.push('year=' + date.substring(0, 4));
-					params.push('month=' + parseInt(date.substring(4, 6), 10));
-				}
-				
-				if (status) params.push('status=' + status);
-				if (change) params.push('change=' + change);
-				
-				if (params.length) url += '&' + params.join('&');
-				window.location.href = url;
-			}
-			
-			$('#filter-by-date, #filter-by-status, #filter-by-change').on('change', applyFilters);
-			$('#post-query-submit').on('click', function(e) {
-				e.preventDefault();
-				applyFilters();
-			});
-		});
-		</script>
 		<?php
 	}
 }

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -65,9 +65,9 @@ class AuditPage {
 	}
 
 	/**
-	 * Posts per page on the audit overview. Sized to show a meaningful slice
-	 * of a typical month without blowing up render time on large months
-	 * (the page renders a hidden modal per row, so the cost is non-trivial).
+	 * Posts per page on the audit overview.
+	 *
+	 * The page renders a hidden modal per row, so large pages are expensive.
 	 *
 	 * @since 1.0.0
 	 * @var int
@@ -165,32 +165,10 @@ class AuditPage {
 	/**
 	 * Sanitizes diff markup for display in the audit modal.
 	 *
-	 * Note: `wp_kses` with `['span' => ['class' => true]]` strips disallowed
-	 * tags but does NOT validate the class attribute value — any class string
-	 * passes. That breaks the "safe to echo" contract on raw input like
-	 * `<span class="evil">x</span>`. We therefore run a second pass that
-	 * drops every <span> whose class is not exactly zw-diff-added or
-	 * zw-diff-removed, keeping its inner content as text. The pattern
-	 * tolerates the variations wp_kses leaves intact: single/double quotes,
-	 * uppercase tag/attribute names, whitespace padding inside the value.
-	 *
-	 * The regex is iterated because a single pass uses non-greedy `(.*?)`
-	 * and binds the outer disallowed span to the FIRST `</span>` it sees —
-	 * for nested disallowed spans like `<span class="a"><span class="b">x
-	 * </span></span>` that leaves the inner span as a top-level survivor.
-	 * Re-running peels one level per pass.
-	 *
-	 * Iterations are bounded by the count of `<span` markers in the
-	 * kses-normalized input: each pass removes at least one disallowed
-	 * span (otherwise the stability check exits), and the substitution is
-	 * `$2` — content between the matched open/close pair — so new `<span`
-	 * markers can never be introduced. If the bound is somehow exceeded we
-	 * MUST NOT return the partially-stripped string (it can still contain
-	 * a live disallowed span); fail closed by stripping all remaining tags.
-	 *
-	 * Centralizing here keeps the modal render path and the regression
-	 * tests in AuditPageDiffAllowlistTest exercising the same sanitizer —
-	 * removing either pass fails those tests, not just the constant lock-in.
+	 * WordPress allows any class value when class is allowed in wp_kses(), so this
+	 * adds a second pass that keeps only the plugin's diff classes and converts
+	 * all other span markup to inert text. Malformed or untrusted output fails
+	 * closed by stripping all remaining tags.
 	 *
 	 * @since 1.0.0
 	 *
@@ -211,19 +189,13 @@ class AuditPage {
 				self::DIFF_ALLOWED_CLASSES
 			)
 		);
-		// Shared predicate: an opening <span...> whose class is NOT in the
-		// allowlist. The paired pattern below requires a matching </span>;
-		// the open-only pattern reuses the same predicate to catch orphan
-		// opens that survived the paired pass (e.g. malformed unbalanced
-		// input like `<span class="a"><span class="b">x</span>`).
+		// Shared predicate for disallowed span opens, reused for paired and
+		// orphan-span checks.
 		$disallowed_open = '<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>';
 		$paired_pattern  = '#' . $disallowed_open . '(.*?)</(?i:span)>#s';
 		$open_pattern    = '#' . $disallowed_open . '#';
 
-		// Tight upper bound: one iteration per span in the input, plus one
-		// final stability check to confirm no further changes. Counted with
-		// the same case-insensitive match the regex above uses so the bound
-		// never undershoots on non-normalized input.
+		// Bound iteration to the number of input spans, plus one stability check.
 		$span_count = preg_match_all( '/<span\b/i', $kses_out );
 		if ( false === $span_count ) {
 			self::report_diff_sanitizer_failure( 'span_count_regex_failed', preg_last_error_msg() );
@@ -774,8 +746,8 @@ class AuditPage {
 								<div class="inside">
 									<div style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
 										<?php
-										// sanitize_diff_panel applies wp_kses with DIFF_ALLOWED_TAGS.
-										echo self::sanitize_diff_panel( $diff['before'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is sanitized by sanitize_diff_panel().
+											echo self::sanitize_diff_panel( $diff['before'] );
 										?>
 									</div>
 								</div>
@@ -788,8 +760,8 @@ class AuditPage {
 								<div class="inside">
 									<div style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
 										<?php
-										// sanitize_diff_panel applies wp_kses with DIFF_ALLOWED_TAGS.
-										echo self::sanitize_diff_panel( $diff['after'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is sanitized by sanitize_diff_panel().
+											echo self::sanitize_diff_panel( $diff['after'] );
 										?>
 									</div>
 								</div>

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -168,7 +168,14 @@ class AuditPage {
 		$kses_out = wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
 
 		$class_pattern = implode( '|', array_map( 'preg_quote', self::DIFF_ALLOWED_CLASSES ) );
-		$pattern       = '#<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>(.*?)</(?i:span)>#s';
+		// Shared predicate: an opening <span...> whose class is NOT in the
+		// allowlist. The paired pattern below requires a matching </span>;
+		// the open-only pattern reuses the same predicate to catch orphan
+		// opens that survived the paired pass (e.g. malformed unbalanced
+		// input like `<span class="a"><span class="b">x</span>`).
+		$disallowed_open = '<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>';
+		$paired_pattern  = '#' . $disallowed_open . '(.*?)</(?i:span)>#s';
+		$open_pattern    = '#' . $disallowed_open . '#';
 
 		// Tight upper bound: one iteration per span in the input, plus one
 		// final stability check to confirm no further changes. Counted with
@@ -178,8 +185,14 @@ class AuditPage {
 
 		$current = $kses_out;
 		for ( $i = 0; $i < $max_iterations; $i++ ) {
-			$next = preg_replace( $pattern, '$2', $current );
+			$next = preg_replace( $paired_pattern, '$2', $current );
 			if ( ! is_string( $next ) || $next === $current ) {
+				// Stable, but the paired regex can only strip balanced
+				// disallowed spans. If a disallowed open survived without a
+				// matching close, fail closed rather than echo live markup.
+				if ( 1 === preg_match( $open_pattern, $current ) ) {
+					return wp_strip_all_tags( $current );
+				}
 				return $current;
 			}
 			$current = $next;

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -99,7 +99,7 @@ class AuditPage {
 	 * @phpstan-param array<int, T> $items
 	 * @phpstan-return array{slice: array<int, T>, paged: int, total_pages: int, total: int}
 	 */
-	public static function paginate( array $items, int $requested_page, int $per_page ): array {
+	private static function paginate( array $items, int $requested_page, int $per_page ): array {
 		$total       = count( $items );
 		$total_pages = $per_page > 0 ? (int) ceil( $total / $per_page ) : 0;
 		$paged       = $total_pages > 0 ? min( max( 1, $requested_page ), $total_pages ) : 1;

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -36,9 +36,24 @@ class AuditPage {
 	private function get_filter_params(): array {
 		// Read-only page - nonce verification not required for display filters.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$year  = isset( $_GET['year'] ) ? absint( $_GET['year'] ) : null;
+		$month = isset( $_GET['month'] ) ? absint( $_GET['month'] ) : null;
+
+		// Fallback for native form submit: the date <select> is named "m" and
+		// emits YYYYMM (e.g. "202604"). The audit.js module splits this into
+		// year+month before navigating, but if JS is unavailable (CSP, encode
+		// failure, etc.) the form posts ?m=YYYYMM directly. Parse it server-side.
+		if ( null === $year && null === $month && isset( $_GET['m'] ) ) {
+			$raw = sanitize_text_field( wp_unslash( $_GET['m'] ) );
+			if ( '' !== $raw && '0' !== $raw && preg_match( '/^\d{6}$/', $raw ) ) {
+				$year  = (int) substr( $raw, 0, 4 );
+				$month = (int) substr( $raw, 4, 2 );
+			}
+		}
+
 		return array(
-			'year'          => isset( $_GET['year'] ) ? absint( $_GET['year'] ) : null,
-			'month'         => isset( $_GET['month'] ) ? absint( $_GET['month'] ) : null,
+			'year'          => $year,
+			'month'         => $month,
 			'status_filter' => isset( $_GET['status'] ) ? sanitize_text_field( $_GET['status'] ) : '',
 			'change_filter' => isset( $_GET['change'] ) ? sanitize_text_field( $_GET['change'] ) : '',
 			'paged'         => isset( $_GET['paged'] ) ? max( 1, absint( $_GET['paged'] ) ) : 1,

--- a/includes/admin/SettingsPage.php
+++ b/includes/admin/SettingsPage.php
@@ -420,11 +420,16 @@ class SettingsPage {
 		if ( isset( $input['api_key'] ) ) {
 			$api_key = sanitize_text_field( $input['api_key'] );
 			if ( ! empty( $api_key ) && ! Helper::is_valid_api_key( $api_key ) ) {
+				$this->logger->error(
+					'Invalid OpenAI API key submitted in settings',
+					array( 'user_id' => get_current_user_id() )
+				);
 				add_settings_error(
 					Constants::SETTINGS_OPTION_NAME,
 					'invalid_api_key',
-					__( 'API-sleutel moet beginnen met "sk-"', 'zw-ttvgpt' )
+					__( 'API-sleutel moet beginnen met "sk-". De ongeldige waarde is niet opgeslagen.', 'zw-ttvgpt' )
 				);
+				$api_key = '';
 			}
 			$sanitized['api_key'] = $api_key;
 		}

--- a/includes/admin/SettingsPage.php
+++ b/includes/admin/SettingsPage.php
@@ -18,9 +18,7 @@ use ZW_TTVGPT_Core\Logger;
 use ZW_TTVGPT_Core\SettingsManager;
 
 /**
- * Settings Page class.
- *
- * Handles settings page rendering and form processing.
+ * Registers, renders, and sanitizes plugin settings.
  *
  * @package ZW_TTVGPT
  * @since   1.0.0
@@ -194,7 +192,7 @@ class SettingsPage {
 	}
 
 	/**
-	 * Renders the API section description.
+	 * Settings API callback for the API section.
 	 *
 	 * @since 1.0.0
 	 */
@@ -203,7 +201,7 @@ class SettingsPage {
 	}
 
 	/**
-	 * Renders the summary section description.
+	 * Settings API callback for summary options.
 	 *
 	 * @since 1.0.0
 	 */
@@ -212,7 +210,7 @@ class SettingsPage {
 	}
 
 	/**
-	 * Renders the debug section description.
+	 * Settings API callback for debug options.
 	 *
 	 * @since 1.0.0
 	 */
@@ -339,8 +337,8 @@ class SettingsPage {
 				class="large-text code"><?php echo esc_textarea( $system_prompt ); ?></textarea>
 		<p class="description">
 			<?php
-			/* translators: %d is a placeholder for the word limit value */
-			esc_html_e( 'De instructies voor het AI-model. Gebruik %d als placeholder voor de woordlimiet.', 'zw-ttvgpt' );
+				/* translators: %d is a literal placeholder for the configured word limit. */
+				esc_html_e( 'De instructies voor het AI-model. Gebruik %d als placeholder voor de woordlimiet.', 'zw-ttvgpt' );
 			?>
 			<br>
 			<small style="color: #666;">
@@ -416,7 +414,6 @@ class SettingsPage {
 	public function sanitize_settings( array $input ): array {
 		$sanitized = array();
 
-		// API Key.
 		if ( isset( $input['api_key'] ) ) {
 			$api_key = sanitize_text_field( $input['api_key'] );
 			if ( ! empty( $api_key ) && ! Helper::is_valid_api_key( $api_key ) ) {
@@ -434,7 +431,6 @@ class SettingsPage {
 			$sanitized['api_key'] = $api_key;
 		}
 
-		// Model.
 		if ( isset( $input['model'] ) ) {
 			$model = sanitize_text_field( $input['model'] );
 			if ( empty( $model ) ) {
@@ -463,7 +459,6 @@ class SettingsPage {
 			$sanitized['model'] = $model;
 		}
 
-		// Word limit.
 		if ( isset( $input['word_limit'] ) ) {
 			$original_word_limit = absint( $input['word_limit'] );
 			$word_limit          = $original_word_limit;
@@ -486,7 +481,6 @@ class SettingsPage {
 			$sanitized['word_limit'] = $word_limit;
 		}
 
-		// System prompt.
 		if ( isset( $input['system_prompt'] ) ) {
 			$system_prompt = sanitize_textarea_field( $input['system_prompt'] );
 			if ( empty( $system_prompt ) ) {
@@ -501,7 +495,6 @@ class SettingsPage {
 			$sanitized['system_prompt'] = $system_prompt;
 		}
 
-		// Debug mode.
 		$sanitized['debug_mode'] = ! empty( $input['debug_mode'] );
 
 		// Redact api_key before logging; debug.log can be world-readable depending on host config.

--- a/includes/admin/SettingsPage.php
+++ b/includes/admin/SettingsPage.php
@@ -285,32 +285,21 @@ class SettingsPage {
 		<p class="description">
 			<?php esc_html_e( 'Aanbevolen: gpt-5.5 (beste kwaliteit)', 'zw-ttvgpt' ); ?>
 		</p>
-
-		<script>
-		(function() {
-			const select = document.getElementById('zw_ttvgpt_model_select');
-			const wrapper = document.getElementById('zw_ttvgpt_legacy_fine_tuned_wrapper');
-			const legacyInput = document.getElementById('zw_ttvgpt_legacy_fine_tuned_model');
-			const fieldName = <?php echo wp_json_encode( $field_name ); ?>;
-			const legacyOptionValue = <?php echo wp_json_encode( self::LEGACY_FINE_TUNED_SELECT_VALUE ); ?>;
-
-			select.addEventListener('change', function() {
-				const isLegacyFineTuned = this.value === legacyOptionValue;
-				wrapper.style.display = isLegacyFineTuned ? 'block' : 'none';
-
-				if (isLegacyFineTuned) {
-					select.removeAttribute('name');
-					legacyInput.setAttribute('name', fieldName);
-					legacyInput.setAttribute('required', 'required');
-				} else {
-					select.setAttribute('name', fieldName);
-					legacyInput.removeAttribute('name');
-					legacyInput.removeAttribute('required');
-				}
-			});
-		})();
-		</script>
 		<?php
+	}
+
+	/**
+	 * Returns the inline JS config consumed by the settings ES module.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{fieldName: string, legacyOptionValue: string}
+	 */
+	public function get_legacy_model_toggle_config(): array {
+		return array(
+			'fieldName'         => $this->get_field_name( 'model' ),
+			'legacyOptionValue' => self::LEGACY_FINE_TUNED_SELECT_VALUE,
+		);
 	}
 
 	/**

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,11 +1,9 @@
 <?php
 /**
- * PHPStan bootstrap file - never loaded by WordPress.
+ * PHPStan bootstrap; not loaded by WordPress.
  *
- * The canonical ABSPATH guard satisfies WordPress plugin-check's direct-access
- * rule. PHPStan can still execute the rest of this file because
- * szepeviktor/phpstan-wordpress runtime-defines ABSPATH in its extension
- * bootstrap, so the guard short-circuits during analysis.
+ * ABSPATH is runtime-defined by phpstan-wordpress, so the direct-access guard
+ * remains plugin-check compatible.
  *
  * @package ZW_TTVGPT
  */

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,7 @@ parameters:
     # Audit types
     FilterParams: 'array{year: int|null, month: int|null, status_filter: string, change_filter: string, paged: int}'
     MonthData: 'array{year: int, month: int}'
+    PaginationResult: 'array{slice: array<int, mixed>, paged: int, total_pages: int, total: int}'
     PostAnalysis: 'array{status: ZW_TTVGPT_Core\AuditStatus, ai_content: string, human_content: string, change_percentage: int}'
     DiffResult: 'array{before: string, after: string}'
     # OpenAI types

--- a/tests/AdminMenuInlineConfigTest.php
+++ b/tests/AdminMenuInlineConfigTest.php
@@ -16,49 +16,6 @@ namespace {
 	if ( ! function_exists( 'add_action' ) ) {
 		require_once ABSPATH . 'wp-includes/plugin.php';
 	}
-
-	if ( ! function_exists( 'wp_json_encode' ) ) {
-		function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
-			return json_encode( $value, $flags, $depth );
-		}
-	}
-
-	if ( ! function_exists( 'admin_url' ) ) {
-		function admin_url( string $path = '', string $scheme = 'admin' ): string {
-			return 'https://example.test/wp-admin/' . $path;
-		}
-	}
-
-	if ( ! function_exists( 'wp_cache_get' ) ) {
-		function wp_cache_get( string $key, string $group = '', bool $force = false, ?bool &$found = null ): mixed {
-			$found = false;
-			return false;
-		}
-	}
-
-	if ( ! function_exists( 'wp_cache_set' ) ) {
-		function wp_cache_set( string $key, mixed $data, string $group = '', int $expire = 0 ): bool {
-			return true;
-		}
-	}
-
-	if ( ! function_exists( 'get_option' ) ) {
-		function get_option( string $option, mixed $default_value = false ): mixed {
-			return $default_value;
-		}
-	}
-
-	if ( ! function_exists( 'wp_enqueue_script_module' ) ) {
-		function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), mixed $version = false, array $args = array() ): void {
-			$GLOBALS['zw_test_script_modules'][] = array(
-				'id'      => $id,
-				'src'     => $src,
-				'deps'    => $deps,
-				'version' => $version,
-				'args'    => $args,
-			);
-		}
-	}
 }
 
 namespace ZW_TTVGPT_Core\Tests {

--- a/tests/AdminMenuInlineConfigTest.php
+++ b/tests/AdminMenuInlineConfigTest.php
@@ -2,6 +2,10 @@
 declare(strict_types=1);
 
 namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
+
 	if ( ! defined( 'ZW_TTVGPT_VERSION' ) ) {
 		define( 'ZW_TTVGPT_VERSION', '1.0.0' );
 	}

--- a/tests/AdminMenuInlineConfigTest.php
+++ b/tests/AdminMenuInlineConfigTest.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace {
+	if ( ! defined( 'ZW_TTVGPT_VERSION' ) ) {
+		define( 'ZW_TTVGPT_VERSION', '1.0.0' );
+	}
+	if ( ! defined( 'ZW_TTVGPT_URL' ) ) {
+		define( 'ZW_TTVGPT_URL', 'https://example.test/wp-content/plugins/zw-ttvgpt/' );
+	}
+
+	if ( ! function_exists( 'add_action' ) ) {
+		require_once ABSPATH . 'wp-includes/plugin.php';
+	}
+
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+			return json_encode( $value, $flags, $depth );
+		}
+	}
+
+	if ( ! function_exists( 'admin_url' ) ) {
+		function admin_url( string $path = '', string $scheme = 'admin' ): string {
+			return 'https://example.test/wp-admin/' . $path;
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_get' ) ) {
+		function wp_cache_get( string $key, string $group = '', bool $force = false, ?bool &$found = null ): mixed {
+			$found = false;
+			return false;
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_set' ) ) {
+		function wp_cache_set( string $key, mixed $data, string $group = '', int $expire = 0 ): bool {
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( string $option, mixed $default_value = false ): mixed {
+			return $default_value;
+		}
+	}
+
+	if ( ! function_exists( 'wp_enqueue_script_module' ) ) {
+		function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), mixed $version = false, array $args = array() ): void {
+			$GLOBALS['zw_test_script_modules'][] = array(
+				'id'      => $id,
+				'src'     => $src,
+				'deps'    => $deps,
+				'version' => $version,
+				'args'    => $args,
+			);
+		}
+	}
+}
+
+namespace ZW_TTVGPT_Core\Tests {
+
+	use PHPUnit\Framework\Attributes\CoversClass;
+	use PHPUnit\Framework\TestCase;
+	use ReflectionClass;
+	use ZW_TTVGPT_Core\Admin\AdminMenu;
+	use ZW_TTVGPT_Core\Admin\SettingsPage;
+	use ZW_TTVGPT_Core\Constants;
+
+	final class BadInlineConfigSettingsPage extends SettingsPage {
+		public function __construct() {}
+
+		public function get_legacy_model_toggle_config(): array {
+			return array( 'bad' => INF );
+		}
+	}
+
+	final class GoodInlineConfigSettingsPage extends SettingsPage {
+		public function __construct() {}
+
+		public function get_legacy_model_toggle_config(): array {
+			return array(
+				'fieldName'         => Constants::SETTINGS_OPTION_NAME . '[model]',
+				'legacyOptionValue' => 'legacy-fine-tuned',
+			);
+		}
+	}
+
+	#[CoversClass(AdminMenu::class)]
+	final class AdminMenuInlineConfigTest extends TestCase {
+
+		protected function setUp(): void {
+			$GLOBALS['zw_test_script_modules'] = array();
+		}
+
+		public function test_settings_module_is_not_enqueued_when_inline_config_encoding_fails(): void {
+			$logger = new RecordingLogger();
+			$menu   = self::newAdminMenu( $logger, new BadInlineConfigSettingsPage() );
+
+			$menu->enqueue_admin_assets( 'settings_page_' . Constants::SETTINGS_PAGE_SLUG );
+
+			self::assertSame( array(), $GLOBALS['zw_test_script_modules'] );
+			self::assertCount( 1, $logger->errors );
+			self::assertStringContainsString( 'Failed to encode inline config for window.zwTTVGPTSettings', $logger->errors[0]['message'] );
+			self::assertSame( 'Inf and NaN cannot be JSON encoded', $logger->errors[0]['context']['json_error'] );
+		}
+
+		public function test_settings_module_is_enqueued_when_inline_config_encoding_succeeds(): void {
+			$logger = new RecordingLogger();
+			$menu   = self::newAdminMenu( $logger, new GoodInlineConfigSettingsPage() );
+
+			$menu->enqueue_admin_assets( 'settings_page_' . Constants::SETTINGS_PAGE_SLUG );
+
+			self::assertSame( 'zw-ttvgpt-settings', $GLOBALS['zw_test_script_modules'][0]['id'] );
+			self::assertSame( array(), $logger->errors );
+		}
+
+		private static function newAdminMenu( RecordingLogger $logger, SettingsPage $settings_page ): AdminMenu {
+			$reflection = new ReflectionClass( AdminMenu::class );
+			$menu       = $reflection->newInstanceWithoutConstructor();
+
+			$logger_property = $reflection->getProperty( 'logger' );
+			$logger_property->setValue( $menu, $logger );
+
+			$settings_page_property = $reflection->getProperty( 'settings_page' );
+			$settings_page_property->setValue( $menu, $settings_page );
+
+			return $menu;
+		}
+	}
+}

--- a/tests/ApiHandlerExtractTest.php
+++ b/tests/ApiHandlerExtractTest.php
@@ -91,8 +91,8 @@ final class ApiHandlerExtractTest extends TestCase {
 
 		$context = $this->logger->errors[0]['context'];
 		self::assertSame( 'chatcmpl-y', $context['id'] );
-			// Fall back to the configured model when the payload omits it.
-			self::assertSame( 'gpt-5.5', $context['model'] );
+		// Fall back to the configured model when the payload omits it.
+		self::assertSame( 'gpt-5.5', $context['model'] );
 	}
 
 	public function test_responses_output_text_helper_returns_trimmed_summary(): void {
@@ -166,8 +166,8 @@ final class ApiHandlerExtractTest extends TestCase {
 		self::assertCount( 1, $this->logger->errors );
 		$context = $this->logger->errors[0]['context'];
 		self::assertSame( 'Responses', $context['api_type'] );
-			// Fall back to the configured model when the payload omits it.
-			self::assertSame( 'gpt-5.5', $context['model'] );
+		// Fall back to the configured model when the payload omits it.
+		self::assertSame( 'gpt-5.5', $context['model'] );
 	}
 
 	public function test_responses_output_without_message_items_returns_invalid_response_error(): void {

--- a/tests/ApiHandlerExtractTest.php
+++ b/tests/ApiHandlerExtractTest.php
@@ -91,8 +91,8 @@ final class ApiHandlerExtractTest extends TestCase {
 
 		$context = $this->logger->errors[0]['context'];
 		self::assertSame( 'chatcmpl-y', $context['id'] );
-		// Configured model must survive into the log even when the response payload omits it.
-		self::assertSame( 'gpt-5.5', $context['model'] );
+			// Fall back to the configured model when the payload omits it.
+			self::assertSame( 'gpt-5.5', $context['model'] );
 	}
 
 	public function test_responses_output_text_helper_returns_trimmed_summary(): void {
@@ -166,8 +166,8 @@ final class ApiHandlerExtractTest extends TestCase {
 		self::assertCount( 1, $this->logger->errors );
 		$context = $this->logger->errors[0]['context'];
 		self::assertSame( 'Responses', $context['api_type'] );
-		// Configured model must survive into the log even when the response payload omits it.
-		self::assertSame( 'gpt-5.5', $context['model'] );
+			// Fall back to the configured model when the payload omits it.
+			self::assertSame( 'gpt-5.5', $context['model'] );
 	}
 
 	public function test_responses_output_without_message_items_returns_invalid_response_error(): void {

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -11,6 +11,10 @@ use ZW_TTVGPT_Core\AuditHelper;
 #[CoversClass(AuditHelper::class)]
 final class AuditHelperRegionPrefixTest extends TestCase {
 
+	public static function setUpBeforeClass(): void {
+		require_once __DIR__ . '/wp-load-helper.php';
+	}
+
 	#[DataProvider('regionPrefixProvider')]
 	public function test_strip_region_prefix( string $input, string $expected ): void {
 		self::assertSame( $expected, AuditHelper::strip_region_prefix( $input ) );
@@ -53,6 +57,14 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 		self::assertSame( 100.0, AuditHelper::calculate_change_percentage( '', 'human content' ) );
 	}
 
+	public function test_calculate_change_percentage_ai_whitespace_returns_max(): void {
+		self::assertSame( 100.0, AuditHelper::calculate_change_percentage( "   \t ", 'human content' ) );
+	}
+
+	public function test_calculate_change_percentage_human_empty_returns_max(): void {
+		self::assertSame( 100.0, AuditHelper::calculate_change_percentage( 'human content', '' ) );
+	}
+
 	public function test_calculate_change_percentage_identical_returns_zero(): void {
 		self::assertSame( 0.0, AuditHelper::calculate_change_percentage( 'same words here', 'same words here' ) );
 	}
@@ -63,5 +75,46 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 			50.0,
 			AuditHelper::calculate_change_percentage( 'the cat sat down', 'the cat ran away' )
 		);
+	}
+
+	public function test_generate_word_diff_falls_back_to_plain_text_when_diff_stripping_regex_fails(): void {
+		$previous_limit = ini_set( 'pcre.backtrack_limit', '1' );
+		$error_log      = tempnam( sys_get_temp_dir(), 'zw-ttvgpt-error-log-' );
+		self::assertIsString( $error_log );
+		$previous_log = ini_set( 'error_log', $error_log );
+		$events       = array();
+
+		add_action(
+			'zw_ttvgpt_audit_regex_failed',
+			static function ( string $operation, int $error_code, string $error_message ) use ( &$events ): void {
+				$events[] = array(
+					'operation' => $operation,
+					'code'      => $error_code,
+					'message'   => $error_message,
+				);
+			},
+			10,
+			3
+		);
+
+		try {
+			$diff = AuditHelper::generate_word_diff( 'oude zin', 'nieuwe zin' );
+		} finally {
+			remove_all_actions( 'zw_ttvgpt_audit_regex_failed' );
+			if ( false !== $previous_limit ) {
+				ini_set( 'pcre.backtrack_limit', $previous_limit );
+			}
+			if ( false !== $previous_log ) {
+				ini_set( 'error_log', $previous_log );
+			}
+			if ( is_file( $error_log ) ) {
+				unlink( $error_log );
+			}
+		}
+
+		self::assertSame( 'oude zin', $diff['before'] );
+		self::assertSame( 'nieuwe zin', $diff['after'] );
+		self::assertNotSame( $diff['before'], $diff['after'], 'PCRE failures must not show the combined diff in both panes.' );
+		self::assertContains( 'remove added diff span for before pane', array_column( $events, 'operation' ) );
 	}
 }

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -43,12 +43,10 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 			'whitespace-only collapses'      => array( "   \t  ", '' ),
 			// trim() removes the trailing space, so the separator no longer matches.
 			'region without trailing body'   => array( 'LEIDEN - ', 'LEIDEN -' ),
-			// One-letter list markers are not region prefixes.
-			'single-letter prefix preserved' => array( 'A - eerste optie', 'A - eerste optie' ),
-			// Two uppercase letters still count as a region prefix.
-			'two-letter prefix still strips' => array( 'EU - mededeling.', 'mededeling.' ),
-			// Regex requires ASCII hyphen; typographic dashes are not treated as separators.
-			'en-dash is not a separator'     => array( 'LEIDEN – Bericht.', 'LEIDEN – Bericht.' ),
+				'single-letter prefix preserved' => array( 'A - eerste optie', 'A - eerste optie' ),
+				'two-letter prefix still strips' => array( 'EU - mededeling.', 'mededeling.' ),
+				// Only ASCII hyphen is a separator.
+				'en-dash is not a separator'     => array( 'LEIDEN – Bericht.', 'LEIDEN – Bericht.' ),
 			'em-dash is not a separator'     => array( 'LEIDEN — Bericht.', 'LEIDEN — Bericht.' ),
 		);
 	}
@@ -74,7 +72,7 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 	}
 
 	public function test_calculate_change_percentage_half_changed(): void {
-		// AI=4 words, human=4 words, shared=2 ('the', 'cat'). Similarity = 2/4 = 0.5 → 50% change.
+		// Four words per side; two shared words means 50% change.
 		self::assertSame(
 			50.0,
 			AuditHelper::calculate_change_percentage( 'the cat sat down', 'the cat ran away' )

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -21,16 +21,25 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 	 */
 	public static function regionPrefixProvider(): array {
 		return array(
-			'simple uppercase region'      => array( 'LEIDEN - Een nieuwsbericht.', 'Een nieuwsbericht.' ),
-			'multi-word region'            => array( 'DEN HAAG - Een nieuwsbericht.', 'Een nieuwsbericht.' ),
-			'slash-separated regions'      => array( 'ROOSENDAAL/OUDENBOSCH - Bericht.', 'Bericht.' ),
-			'hyphenated region'            => array( 'ETTEN-LEUR - Bericht.', 'Bericht.' ),
+			'simple uppercase region'        => array( 'LEIDEN - Een nieuwsbericht.', 'Een nieuwsbericht.' ),
+			'multi-word region'              => array( 'DEN HAAG - Een nieuwsbericht.', 'Een nieuwsbericht.' ),
+			'slash-separated regions'        => array( 'ROOSENDAAL/OUDENBOSCH - Bericht.', 'Bericht.' ),
+			'hyphenated region'              => array( 'ETTEN-LEUR - Bericht.', 'Bericht.' ),
 			// Regression: pre-fix ASCII-only character class skipped diacritics.
-			'diacritic region (cedilla)'   => array( 'CURAÇAO - Bericht.', 'Bericht.' ),
-			'diacritic region (umlaut)'   => array( 'ZÜRICH - Bericht.', 'Bericht.' ),
-			'no prefix is left untouched'  => array( 'Geen prefix hier.', 'Geen prefix hier.' ),
-			'lowercase is not a prefix'    => array( 'leiden - geen prefix.', 'leiden - geen prefix.' ),
-			'leading whitespace stripped'  => array( '   LEIDEN - Bericht.', 'Bericht.' ),
+			'diacritic region (cedilla)'     => array( 'CURAÇAO - Bericht.', 'Bericht.' ),
+			'diacritic region (umlaut)'      => array( 'ZÜRICH - Bericht.', 'Bericht.' ),
+			'no prefix is left untouched'    => array( 'Geen prefix hier.', 'Geen prefix hier.' ),
+			'lowercase is not a prefix'      => array( 'leiden - geen prefix.', 'leiden - geen prefix.' ),
+			'leading whitespace stripped'    => array( '   LEIDEN - Bericht.', 'Bericht.' ),
+			'empty string passes through'    => array( '', '' ),
+			'whitespace-only collapses'      => array( "   \t  ", '' ),
+			// trim() runs first so the trailing space is gone, breaking the `\s-\s` anchor.
+			'region without trailing body'   => array( 'LEIDEN - ', 'LEIDEN -' ),
+			// Single-letter prefix currently matches; documenting behaviour, not endorsing it.
+			'single-letter prefix matches'   => array( 'A - bericht', 'bericht' ),
+			// Regex requires ASCII hyphen; typographic dashes are not treated as separators.
+			'en-dash is not a separator'     => array( 'LEIDEN – Bericht.', 'LEIDEN – Bericht.' ),
+			'em-dash is not a separator'     => array( 'LEIDEN — Bericht.', 'LEIDEN — Bericht.' ),
 		);
 	}
 

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -8,6 +8,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZW_TTVGPT_Core\AuditHelper;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 #[CoversClass(AuditHelper::class)]
 final class AuditHelperRegionPrefixTest extends TestCase {
 
@@ -37,11 +41,11 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 			'leading whitespace stripped'    => array( '   LEIDEN - Bericht.', 'Bericht.' ),
 			'empty string passes through'    => array( '', '' ),
 			'whitespace-only collapses'      => array( "   \t  ", '' ),
-			// trim() runs first so the trailing space is gone, breaking the `\s-\s` anchor.
+			// trim() removes the trailing space, so the separator no longer matches.
 			'region without trailing body'   => array( 'LEIDEN - ', 'LEIDEN -' ),
-			// Listicle/enumeration markers are not regions; the regex requires ≥2 uppercase letters.
+			// One-letter list markers are not region prefixes.
 			'single-letter prefix preserved' => array( 'A - eerste optie', 'A - eerste optie' ),
-			// A real two-letter abbreviation still strips — conservative threshold, not strict.
+			// Two uppercase letters still count as a region prefix.
 			'two-letter prefix still strips' => array( 'EU - mededeling.', 'mededeling.' ),
 			// Regex requires ASCII hyphen; typographic dashes are not treated as separators.
 			'en-dash is not a separator'     => array( 'LEIDEN – Bericht.', 'LEIDEN – Bericht.' ),

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -81,42 +81,17 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 
 	public function test_generate_word_diff_falls_back_to_plain_text_when_diff_stripping_regex_fails(): void {
 		$previous_limit = ini_set( 'pcre.backtrack_limit', '1' );
-		$error_log      = tempnam( sys_get_temp_dir(), 'zw-ttvgpt-error-log-' );
-		self::assertIsString( $error_log );
-		$previous_log = ini_set( 'error_log', $error_log );
-		$events       = array();
-
-		add_action(
-			'zw_ttvgpt_audit_regex_failed',
-			static function ( string $operation, int $error_code, string $error_message ) use ( &$events ): void {
-				$events[] = array(
-					'operation' => $operation,
-					'code'      => $error_code,
-					'message'   => $error_message,
-				);
-			},
-			10,
-			3
-		);
 
 		try {
 			$diff = AuditHelper::generate_word_diff( 'oude zin', 'nieuwe zin' );
 		} finally {
-			remove_all_actions( 'zw_ttvgpt_audit_regex_failed' );
 			if ( false !== $previous_limit ) {
 				ini_set( 'pcre.backtrack_limit', $previous_limit );
-			}
-			if ( false !== $previous_log ) {
-				ini_set( 'error_log', $previous_log );
-			}
-			if ( is_file( $error_log ) ) {
-				unlink( $error_log );
 			}
 		}
 
 		self::assertSame( 'oude zin', $diff['before'] );
 		self::assertSame( 'nieuwe zin', $diff['after'] );
 		self::assertNotSame( $diff['before'], $diff['after'], 'PCRE failures must not show the combined diff in both panes.' );
-		self::assertContains( 'remove added diff span for before pane', array_column( $events, 'operation' ) );
 	}
 }

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -35,8 +35,10 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 			'whitespace-only collapses'      => array( "   \t  ", '' ),
 			// trim() runs first so the trailing space is gone, breaking the `\s-\s` anchor.
 			'region without trailing body'   => array( 'LEIDEN - ', 'LEIDEN -' ),
-			// Single-letter prefix currently matches; documenting behaviour, not endorsing it.
-			'single-letter prefix matches'   => array( 'A - bericht', 'bericht' ),
+			// Listicle/enumeration markers are not regions; the regex requires ≥2 uppercase letters.
+			'single-letter prefix preserved' => array( 'A - eerste optie', 'A - eerste optie' ),
+			// A real two-letter abbreviation still strips — conservative threshold, not strict.
+			'two-letter prefix still strips' => array( 'EU - mededeling.', 'mededeling.' ),
 			// Regex requires ASCII hyphen; typographic dashes are not treated as separators.
 			'en-dash is not a separator'     => array( 'LEIDEN – Bericht.', 'LEIDEN – Bericht.' ),
 			'em-dash is not a separator'     => array( 'LEIDEN — Bericht.', 'LEIDEN — Bericht.' ),

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -43,10 +43,10 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 			'whitespace-only collapses'      => array( "   \t  ", '' ),
 			// trim() removes the trailing space, so the separator no longer matches.
 			'region without trailing body'   => array( 'LEIDEN - ', 'LEIDEN -' ),
-				'single-letter prefix preserved' => array( 'A - eerste optie', 'A - eerste optie' ),
-				'two-letter prefix still strips' => array( 'EU - mededeling.', 'mededeling.' ),
-				// Only ASCII hyphen is a separator.
-				'en-dash is not a separator'     => array( 'LEIDEN – Bericht.', 'LEIDEN – Bericht.' ),
+			'single-letter prefix preserved' => array( 'A - eerste optie', 'A - eerste optie' ),
+			'two-letter prefix still strips' => array( 'EU - mededeling.', 'mededeling.' ),
+			// Only ASCII hyphen is a separator.
+			'en-dash is not a separator'     => array( 'LEIDEN – Bericht.', 'LEIDEN – Bericht.' ),
 			'em-dash is not a separator'     => array( 'LEIDEN — Bericht.', 'LEIDEN — Bericht.' ),
 		);
 	}

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZW_TTVGPT_Core\AuditHelper;
+
+#[CoversClass(AuditHelper::class)]
+final class AuditHelperRegionPrefixTest extends TestCase {
+
+	#[DataProvider('regionPrefixProvider')]
+	public function test_strip_region_prefix( string $input, string $expected ): void {
+		self::assertSame( $expected, AuditHelper::strip_region_prefix( $input ) );
+	}
+
+	/**
+	 * @return array<string, array{string, string}>
+	 */
+	public static function regionPrefixProvider(): array {
+		return array(
+			'simple uppercase region'      => array( 'LEIDEN - Een nieuwsbericht.', 'Een nieuwsbericht.' ),
+			'multi-word region'            => array( 'DEN HAAG - Een nieuwsbericht.', 'Een nieuwsbericht.' ),
+			'slash-separated regions'      => array( 'ROOSENDAAL/OUDENBOSCH - Bericht.', 'Bericht.' ),
+			'hyphenated region'            => array( 'ETTEN-LEUR - Bericht.', 'Bericht.' ),
+			// Regression: pre-fix ASCII-only character class skipped diacritics.
+			'diacritic region (cedilla)'   => array( 'CURAÇAO - Bericht.', 'Bericht.' ),
+			'diacritic region (umlaut)'   => array( 'ZÜRICH - Bericht.', 'Bericht.' ),
+			'no prefix is left untouched'  => array( 'Geen prefix hier.', 'Geen prefix hier.' ),
+			'lowercase is not a prefix'    => array( 'leiden - geen prefix.', 'leiden - geen prefix.' ),
+			'leading whitespace stripped'  => array( '   LEIDEN - Bericht.', 'Bericht.' ),
+		);
+	}
+
+	public function test_calculate_change_percentage_both_empty(): void {
+		self::assertSame( 0.0, AuditHelper::calculate_change_percentage( '', '' ) );
+	}
+
+	public function test_calculate_change_percentage_ai_empty_returns_max(): void {
+		self::assertSame( 100.0, AuditHelper::calculate_change_percentage( '', 'human content' ) );
+	}
+
+	public function test_calculate_change_percentage_identical_returns_zero(): void {
+		self::assertSame( 0.0, AuditHelper::calculate_change_percentage( 'same words here', 'same words here' ) );
+	}
+
+	public function test_calculate_change_percentage_half_changed(): void {
+		// AI=4 words, human=4 words, shared=2 ('the', 'cat'). Similarity = 2/4 = 0.5 → 50% change.
+		self::assertSame(
+			50.0,
+			AuditHelper::calculate_change_percentage( 'the cat sat down', 'the cat ran away' )
+		);
+	}
+}

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -108,6 +108,14 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 			'raw iframe bypasses Text_Diff escaping'       => array( '<iframe src="https://evil.example/"></iframe><span class="zw-diff-removed">x</span>' ),
 			'raw javascript: anchor'                       => array( '<a href="javascript:alert(1)">klik</a>' ),
 			'nested script inside diff span'               => array( '<span class="zw-diff-added">ok<script>alert(1)</script></span>' ),
+			// wp_kses allows `class` as an attribute but does not validate its
+			// value, so a `class="evil"` span passes wp_kses(['span' => ['class' => true]]).
+			// The helper must enforce the class allowlist itself.
+			'span with non-diff class'                     => array( '<span class="evil">x</span>' ),
+			'span with non-diff class plus legit diff'     => array( '<span class="evil">x</span><span class="zw-diff-added">ok</span>' ),
+			'span with extra class alongside diff class'   => array( '<span class="zw-diff-added evil">x</span>' ),
+			'span with no class attribute at all'          => array( '<span>x</span><span class="zw-diff-added">ok</span>' ),
+			'span with single-quoted non-diff class'       => array( "<span class='evil'>x</span>" ),
 		);
 	}
 

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -10,6 +10,10 @@ use ReflectionClass;
 use ZW_TTVGPT_Core\Admin\AuditPage;
 use ZW_TTVGPT_Core\AuditHelper;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 #[CoversClass(AuditPage::class)]
 #[CoversClass(AuditHelper::class)]
 final class AuditPageDiffAllowlistTest extends TestCase {
@@ -43,8 +47,6 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	public function test_malicious_content_cannot_survive_diff_render_pipeline( string $ai_content, string $human_content ): void {
 		$diff = AuditHelper::generate_word_diff( $ai_content, $human_content );
 
-		// Call the same sanitizer the modal render path calls (AuditPage::sanitize_diff_panel)
-		// so removing wp_kses from that helper fails these tests, not just the constant lock-in.
 		$sanitized_before = AuditPage::sanitize_diff_panel( $diff['before'] );
 		$sanitized_after  = AuditPage::sanitize_diff_panel( $diff['after'] );
 
@@ -53,11 +55,10 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	}
 
 	/**
-	 * Strips diff-span open and close tags only (not their inner content) and
-	 * asserts no tag-shaped markup remains. Catches any unencoded `<...>` that
-	 * wp_kses failed to neutralize — including a hypothetical nested tag inside
-	 * a diff span — while tolerating dangerous *words* (onerror, javascript:)
-	 * appearing as inert text inside encoded fragments like `&lt;img ...&gt;`.
+	 * Asserts that only plugin diff spans remain as live HTML.
+	 *
+	 * @param string $sanitized Sanitized HTML.
+	 * @param string $pane_label Assertion label.
 	 */
 	private static function assertOnlyDiffSpansAsLiveHtml( string $sanitized, string $pane_label ): void {
 		$stripped = preg_replace( '#<span class="zw-diff-(?:added|removed)">|</span>#', '', $sanitized );
@@ -85,12 +86,9 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	}
 
 	/**
-	 * Direct helper test that bypasses generate_word_diff. WP's Text_Diff
-	 * renderer htmlspecialchars-encodes input before wrapping, so the integration
-	 * tests above would also pass if someone removed wp_kses from
-	 * sanitize_diff_panel. This test feeds un-encoded markup straight into the
-	 * helper, so removing the wp_kses call breaks here even though the diff
-	 * renderer's defence is gone.
+	 * Feeds raw markup into the sanitizer without relying on Text_Diff escaping.
+	 *
+	 * @param string $raw_input Raw diff HTML.
 	 */
 	#[DataProvider('rawSanitizerProvider')]
 	public function test_sanitize_diff_panel_strips_unencoded_markup( string $raw_input ): void {
@@ -108,9 +106,7 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 			'raw iframe bypasses Text_Diff escaping'       => array( '<iframe src="https://evil.example/"></iframe><span class="zw-diff-removed">x</span>' ),
 			'raw javascript: anchor'                       => array( '<a href="javascript:alert(1)">klik</a>' ),
 			'nested script inside diff span'               => array( '<span class="zw-diff-added">ok<script>alert(1)</script></span>' ),
-			// wp_kses allows `class` as an attribute but does not validate its
-			// value, so a `class="evil"` span passes wp_kses(['span' => ['class' => true]]).
-			// The helper must enforce the class allowlist itself.
+			// wp_kses allows class values; the helper must enforce the allowlist.
 			'span with non-diff class'                     => array( '<span class="evil">x</span>' ),
 			'span with non-diff class plus legit diff'     => array( '<span class="evil">x</span><span class="zw-diff-added">ok</span>' ),
 			'span with extra class alongside diff class'   => array( '<span class="zw-diff-added evil">x</span>' ),
@@ -132,12 +128,10 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	}
 
 	/**
-	 * Pins exact sanitizer output for cases the looser tag-shape assertion misses:
-	 * nested disallowed spans (the regex's non-greedy `(.*?)` would otherwise leave
-	 * the inner span surviving as a top-level node), multi-class values that are
-	 * not exactly an allowlist entry, and entity-encoded class values that would
-	 * decode to an allowlist entry in the browser. The expected outputs are the
-	 * security contract: disallowed spans must collapse to inert text.
+	 * Pins exact sanitizer output for cases the looser tag-shape assertion misses.
+	 *
+	 * @param string $raw_input Raw diff HTML.
+	 * @param string $expected Expected sanitized output.
 	 */
 	#[DataProvider('strictSanitizerProvider')]
 	public function test_sanitize_diff_panel_strips_disallowed_to_inert_text( string $raw_input, string $expected ): void {
@@ -165,10 +159,7 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 				'<span class="a"><span class="b"><span class="c">deep</span></span></span>',
 				'deep',
 			),
-			// Unbalanced input: outer disallowed has no matching </span>, so
-			// the paired regex strips the outer up to the inner close and
-			// leaves the inner open as an orphan. Must fail closed via
-			// wp_strip_all_tags rather than return the live inner open tag.
+			// Malformed nesting must fail closed instead of returning an orphan span.
 			'unbalanced outer disallowed leaks inner open if not fail-closed' => array(
 				'<span class="evil"><span class="also-evil">x</span>',
 				'x',
@@ -181,12 +172,9 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	}
 
 	/**
-	 * Guards against the iteration bound being too tight. A fixed cap (e.g. 20)
-	 * would fail open here: after exhausting iterations the function would
-	 * return a string that still contained a live disallowed span. The bound
-	 * must scale with the input — or fail closed by stripping all markup.
+	 * Guards against fixed iteration caps that could return live disallowed spans.
 	 *
-	 * @param int $depth Nesting depth to exercise.
+	 * @param int $depth Nesting depth.
 	 */
 	#[DataProvider('deepNestingDepthProvider')]
 	public function test_sanitize_diff_panel_handles_deep_nested_disallowed_spans( int $depth ): void {

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -19,9 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class AuditPageDiffAllowlistTest extends TestCase {
 
 	/**
-	 * The allowlist the constant lock-in test pins. Kept here, not derived from
-	 * AuditPage::DIFF_ALLOWED_TAGS, so widening the constant on the production
-	 * side fails this test instead of silently propagating into the assertions.
+	 * Expected DIFF_ALLOWED_TAGS value, independent from production.
 	 *
 	 * @var array<string, array<string, bool>>
 	 */

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -130,4 +130,53 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 		self::assertStringContainsString( 'bericht', $sanitized_before );
 		self::assertStringContainsString( 'bericht', $sanitized_after );
 	}
+
+	/**
+	 * Pins exact sanitizer output for cases the looser tag-shape assertion misses:
+	 * nested disallowed spans (the regex's non-greedy `(.*?)` would otherwise leave
+	 * the inner span surviving as a top-level node), multi-class values that are
+	 * not exactly an allowlist entry, and entity-encoded class values that would
+	 * decode to an allowlist entry in the browser. The expected outputs are the
+	 * security contract: disallowed spans must collapse to inert text.
+	 */
+	#[DataProvider('strictSanitizerProvider')]
+	public function test_sanitize_diff_panel_strips_disallowed_to_inert_text( string $raw_input, string $expected ): void {
+		self::assertSame( $expected, AuditPage::sanitize_diff_panel( $raw_input ) );
+	}
+
+	/**
+	 * @return array<string, array{string, string}>
+	 */
+	public static function strictSanitizerProvider(): array {
+		return array(
+			'nested disallowed spans (both stripped, no orphan markup)' => array(
+				'<span class="evil"><span class="also-evil">x</span></span>',
+				'x',
+			),
+			'multi-class value is not a partial allowlist match' => array(
+				'<span class="zw-diff-added evil">x</span>',
+				'x',
+			),
+			'entity-encoded class does not decode into allowlist' => array(
+				'<span class="zw-diff-&#x61;dded">x</span>',
+				'x',
+			),
+			'three-deep disallowed nesting collapses to text' => array(
+				'<span class="a"><span class="b"><span class="c">deep</span></span></span>',
+				'deep',
+			),
+		);
+	}
+
+	public function test_legitimate_diff_with_angle_brackets_renders_as_entities(): void {
+		$diff = AuditHelper::generate_word_diff( '5 < 10 of niet', '5 < 11 of niet' );
+
+		$sanitized_before = AuditPage::sanitize_diff_panel( $diff['before'] );
+		$sanitized_after  = AuditPage::sanitize_diff_panel( $diff['after'] );
+
+		self::assertStringContainsString( '&lt;', $sanitized_before, 'Literal `<` from user text must survive as entity in BEFORE pane.' );
+		self::assertStringContainsString( '&lt;', $sanitized_after, 'Literal `<` from user text must survive as entity in AFTER pane.' );
+		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_before, 'BEFORE pane' );
+		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_after, 'AFTER pane' );
+	}
 }

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -168,6 +168,34 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Guards against the iteration bound being too tight. A fixed cap (e.g. 20)
+	 * would fail open here: after exhausting iterations the function would
+	 * return a string that still contained a live disallowed span. The bound
+	 * must scale with the input — or fail closed by stripping all markup.
+	 *
+	 * @param int $depth Nesting depth to exercise.
+	 */
+	#[DataProvider('deepNestingDepthProvider')]
+	public function test_sanitize_diff_panel_handles_deep_nested_disallowed_spans( int $depth ): void {
+		$input  = str_repeat( '<span class="evil">', $depth ) . 'x' . str_repeat( '</span>', $depth );
+		$output = AuditPage::sanitize_diff_panel( $input );
+
+		self::assertSame( 'x', $output, sprintf( 'Depth %d must collapse to inert text.', $depth ) );
+		self::assertOnlyDiffSpansAsLiveHtml( $output, sprintf( 'depth %d output', $depth ) );
+	}
+
+	/**
+	 * @return array<string, array{int}>
+	 */
+	public static function deepNestingDepthProvider(): array {
+		return array(
+			'21 deep (just past the old fixed cap)' => array( 21 ),
+			'25 deep'                               => array( 25 ),
+			'50 deep'                               => array( 50 ),
+		);
+	}
+
 	public function test_legitimate_diff_with_angle_brackets_renders_as_entities(): void {
 		$diff = AuditHelper::generate_word_diff( '5 < 10 of niet', '5 < 11 of niet' );
 

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -4,30 +4,93 @@ declare(strict_types=1);
 namespace ZW_TTVGPT_Core\Tests;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ZW_TTVGPT_Core\Admin\AuditPage;
+use ZW_TTVGPT_Core\AuditHelper;
 
 #[CoversClass(AuditPage::class)]
+#[CoversClass(AuditHelper::class)]
 final class AuditPageDiffAllowlistTest extends TestCase {
 
 	/**
-	 * The diff markup rendered into the audit modal is passed through
-	 * wp_kses(..., DIFF_ALLOWED_TAGS) as a defence-in-depth layer on top of
-	 * WordPress' diff renderer (which htmlspecialchars-encodes content before
-	 * wrapping). This test pins the allowlist so any future expansion
-	 * (anchors, images, inline styles) has to be a deliberate decision rather
-	 * than an accidental relaxation of the trust boundary.
+	 * Mirrors AuditPage::DIFF_ALLOWED_TAGS so the integration tests assert what
+	 * the renderer at AuditPage.php:583/594 actually uses. The first test below
+	 * fails the suite if the two ever drift.
+	 *
+	 * @var array<string, array<string, bool>>
 	 */
-	public function test_diff_allowlist_permits_only_span_with_class(): void {
+	private const array EXPECTED_ALLOWLIST = array( 'span' => array( 'class' => true ) );
+
+	public static function setUpBeforeClass(): void {
+		require_once __DIR__ . '/wp-load-helper.php';
+	}
+
+	public function test_diff_allowlist_constant_only_permits_span_with_class(): void {
 		$reflection = new ReflectionClass( AuditPage::class );
 		$constant   = $reflection->getReflectionConstant( 'DIFF_ALLOWED_TAGS' );
 
 		self::assertNotFalse( $constant, 'DIFF_ALLOWED_TAGS constant must exist on AuditPage.' );
 		self::assertSame(
-			array( 'span' => array( 'class' => true ) ),
+			self::EXPECTED_ALLOWLIST,
 			$constant->getValue(),
-			'DIFF_ALLOWED_TAGS must only permit <span class="...">; widening it expands XSS surface.'
+			'Widening DIFF_ALLOWED_TAGS expands the modal trust boundary; require deliberate review.'
 		);
+	}
+
+	#[DataProvider('maliciousContentProvider')]
+	public function test_malicious_content_cannot_survive_diff_render_pipeline( string $ai_content, string $human_content ): void {
+		$diff = AuditHelper::generate_word_diff( $ai_content, $human_content );
+
+		$sanitized_before = wp_kses( $diff['before'], self::EXPECTED_ALLOWLIST );
+		$sanitized_after  = wp_kses( $diff['after'], self::EXPECTED_ALLOWLIST );
+
+		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_before, 'BEFORE pane' );
+		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_after, 'AFTER pane' );
+	}
+
+	/**
+	 * Strips the only HTML the renderer is supposed to emit (zw-diff-added /
+	 * zw-diff-removed spans) and asserts nothing tag-shaped remains. Catches
+	 * any unencoded `<...>` that wp_kses failed to neutralize, while
+	 * tolerating dangerous *words* (onerror, javascript:) appearing as inert
+	 * text inside encoded fragments like `&lt;img onerror=...&gt;`.
+	 */
+	private static function assertOnlyDiffSpansAsLiveHtml( string $sanitized, string $pane_label ): void {
+		$stripped = preg_replace( '#<span class="zw-diff-(?:added|removed)">.*?</span>#s', '', $sanitized );
+		self::assertIsString( $stripped, 'preg_replace must return a string.' );
+		self::assertDoesNotMatchRegularExpression(
+			'/<[a-zA-Z!?\/]/',
+			$stripped,
+			sprintf( 'Live HTML markup other than diff spans survived in %s: %s', $pane_label, $sanitized )
+		);
+	}
+
+	/**
+	 * @return array<string, array{string, string}>
+	 */
+	public static function maliciousContentProvider(): array {
+		return array(
+			'script tag in AI content'       => array( '<script>alert(1)</script> bericht', 'bewerkt bericht' ),
+			'script tag in human content'    => array( 'bericht', '<script>alert(1)</script> bewerkt' ),
+			'img onerror in AI content'      => array( '<img src=x onerror="alert(1)">tekst', 'tekst veranderd' ),
+			'javascript: protocol in anchor' => array( '<a href="javascript:alert(1)">klik</a> hier', 'klik hier veranderd' ),
+			'iframe in AI content'           => array( '<iframe src="https://evil.example/"></iframe> bericht', 'bewerkt bericht' ),
+			'svg with onload handler'        => array( '<svg onload="alert(1)"></svg> bericht', 'bewerkt bericht' ),
+			'style attribute on raw span'    => array( '<span style="background:url(javascript:alert(1))">x</span>', 'x veranderd' ),
+		);
+	}
+
+	public function test_legitimate_diff_spans_survive_sanitization(): void {
+		$diff = AuditHelper::generate_word_diff( 'het originele bericht hier', 'het bewerkte bericht hier' );
+
+		$sanitized_before = wp_kses( $diff['before'], self::EXPECTED_ALLOWLIST );
+		$sanitized_after  = wp_kses( $diff['after'], self::EXPECTED_ALLOWLIST );
+
+		self::assertStringContainsString( '<span class="zw-diff-removed"', $sanitized_before, 'Removed-content spans must survive sanitization.' );
+		self::assertStringContainsString( '<span class="zw-diff-added"', $sanitized_after, 'Added-content spans must survive sanitization.' );
+		self::assertStringContainsString( 'bericht', $sanitized_before );
+		self::assertStringContainsString( 'bericht', $sanitized_after );
 	}
 }

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -15,9 +15,9 @@ use ZW_TTVGPT_Core\AuditHelper;
 final class AuditPageDiffAllowlistTest extends TestCase {
 
 	/**
-	 * Mirrors AuditPage::DIFF_ALLOWED_TAGS so the integration tests assert what
-	 * the renderer at AuditPage.php:583/594 actually uses. The first test below
-	 * fails the suite if the two ever drift.
+	 * The allowlist the constant lock-in test pins. Kept here, not derived from
+	 * AuditPage::DIFF_ALLOWED_TAGS, so widening the constant on the production
+	 * side fails this test instead of silently propagating into the assertions.
 	 *
 	 * @var array<string, array<string, bool>>
 	 */
@@ -43,8 +43,10 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	public function test_malicious_content_cannot_survive_diff_render_pipeline( string $ai_content, string $human_content ): void {
 		$diff = AuditHelper::generate_word_diff( $ai_content, $human_content );
 
-		$sanitized_before = wp_kses( $diff['before'], self::EXPECTED_ALLOWLIST );
-		$sanitized_after  = wp_kses( $diff['after'], self::EXPECTED_ALLOWLIST );
+		// Call the same sanitizer the modal render path calls (AuditPage::sanitize_diff_panel)
+		// so removing wp_kses from that helper fails these tests, not just the constant lock-in.
+		$sanitized_before = AuditPage::sanitize_diff_panel( $diff['before'] );
+		$sanitized_after  = AuditPage::sanitize_diff_panel( $diff['after'] );
 
 		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_before, 'BEFORE pane' );
 		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_after, 'AFTER pane' );
@@ -82,11 +84,38 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Direct helper test that bypasses generate_word_diff. WP's Text_Diff
+	 * renderer htmlspecialchars-encodes input before wrapping, so the integration
+	 * tests above would also pass if someone removed wp_kses from
+	 * sanitize_diff_panel. This test feeds un-encoded markup straight into the
+	 * helper, so removing the wp_kses call breaks here even though the diff
+	 * renderer's defence is gone.
+	 */
+	#[DataProvider('rawSanitizerProvider')]
+	public function test_sanitize_diff_panel_strips_unencoded_markup( string $raw_input ): void {
+		$sanitized = AuditPage::sanitize_diff_panel( $raw_input );
+		self::assertOnlyDiffSpansAsLiveHtml( $sanitized, 'direct helper input' );
+	}
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public static function rawSanitizerProvider(): array {
+		return array(
+			'raw script tag bypasses Text_Diff escaping'   => array( '<span class="zw-diff-added">ok</span><script>alert(1)</script>' ),
+			'raw img onerror bypasses Text_Diff escaping'  => array( '<img src=x onerror="alert(1)"><span class="zw-diff-added">ok</span>' ),
+			'raw iframe bypasses Text_Diff escaping'       => array( '<iframe src="https://evil.example/"></iframe><span class="zw-diff-removed">x</span>' ),
+			'raw javascript: anchor'                       => array( '<a href="javascript:alert(1)">klik</a>' ),
+			'nested script inside diff span'               => array( '<span class="zw-diff-added">ok<script>alert(1)</script></span>' ),
+		);
+	}
+
 	public function test_legitimate_diff_spans_survive_sanitization(): void {
 		$diff = AuditHelper::generate_word_diff( 'het originele bericht hier', 'het bewerkte bericht hier' );
 
-		$sanitized_before = wp_kses( $diff['before'], self::EXPECTED_ALLOWLIST );
-		$sanitized_after  = wp_kses( $diff['after'], self::EXPECTED_ALLOWLIST );
+		$sanitized_before = AuditPage::sanitize_diff_panel( $diff['before'] );
+		$sanitized_after  = AuditPage::sanitize_diff_panel( $diff['after'] );
 
 		self::assertStringContainsString( '<span class="zw-diff-removed"', $sanitized_before, 'Removed-content spans must survive sanitization.' );
 		self::assertStringContainsString( '<span class="zw-diff-added"', $sanitized_after, 'Added-content spans must survive sanitization.' );

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -219,4 +219,75 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_before, 'BEFORE pane' );
 		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_after, 'AFTER pane' );
 	}
+
+	public function test_sanitize_diff_panel_reports_orphan_disallowed_open_fail_closed(): void {
+		$events = array();
+
+		add_action(
+			'zw_ttvgpt_diff_sanitizer_failed',
+			static function ( string $reason, string $error_message ) use ( &$events ): void {
+				$events[] = array(
+					'reason'  => $reason,
+					'message' => $error_message,
+				);
+			},
+			10,
+			2
+		);
+
+		try {
+			self::assertSame( 'trailing text', AuditPage::sanitize_diff_panel( '<span class="evil">trailing text' ) );
+		} finally {
+			remove_all_actions( 'zw_ttvgpt_diff_sanitizer_failed' );
+		}
+
+		self::assertSame(
+			array(
+				array(
+					'reason'  => 'orphan_disallowed_span',
+					'message' => '',
+				),
+			),
+			$events
+		);
+	}
+
+	public function test_sanitize_diff_panel_fails_closed_when_kses_filter_returns_non_string(): void {
+		$events = array();
+
+		add_filter(
+			'pre_kses',
+			static fn (): array => array( 'unexpected' ),
+			10,
+			0
+		);
+		add_action(
+			'zw_ttvgpt_diff_sanitizer_failed',
+			static function ( string $reason, string $error_message ) use ( &$events ): void {
+				$events[] = array(
+					'reason'  => $reason,
+					'message' => $error_message,
+				);
+			},
+			10,
+			2
+		);
+
+		try {
+			self::assertSame( 'x', AuditPage::sanitize_diff_panel( '<span class="evil">x</span>' ) );
+		} finally {
+			remove_all_filters( 'pre_kses' );
+			remove_all_actions( 'zw_ttvgpt_diff_sanitizer_failed' );
+		}
+
+		self::assertSame(
+			array(
+				array(
+					'reason'  => 'wp_kses_non_string',
+					'message' => '',
+				),
+			),
+			$events
+		);
+	}
 }

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ZW_TTVGPT_Core\Admin\AuditPage;
+
+#[CoversClass(AuditPage::class)]
+final class AuditPageDiffAllowlistTest extends TestCase {
+
+	/**
+	 * The diff markup rendered into the audit modal is passed through
+	 * wp_kses(..., DIFF_ALLOWED_TAGS) as a defence-in-depth layer on top of
+	 * WordPress' diff renderer (which htmlspecialchars-encodes content before
+	 * wrapping). This test pins the allowlist so any future expansion
+	 * (anchors, images, inline styles) has to be a deliberate decision rather
+	 * than an accidental relaxation of the trust boundary.
+	 */
+	public function test_diff_allowlist_permits_only_span_with_class(): void {
+		$reflection = new ReflectionClass( AuditPage::class );
+		$constant   = $reflection->getReflectionConstant( 'DIFF_ALLOWED_TAGS' );
+
+		self::assertNotFalse( $constant, 'DIFF_ALLOWED_TAGS constant must exist on AuditPage.' );
+		self::assertSame(
+			array( 'span' => array( 'class' => true ) ),
+			$constant->getValue(),
+			'DIFF_ALLOWED_TAGS must only permit <span class="...">; widening it expands XSS surface.'
+		);
+	}
+}

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -51,14 +51,14 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	}
 
 	/**
-	 * Strips the only HTML the renderer is supposed to emit (zw-diff-added /
-	 * zw-diff-removed spans) and asserts nothing tag-shaped remains. Catches
-	 * any unencoded `<...>` that wp_kses failed to neutralize, while
-	 * tolerating dangerous *words* (onerror, javascript:) appearing as inert
-	 * text inside encoded fragments like `&lt;img onerror=...&gt;`.
+	 * Strips diff-span open and close tags only (not their inner content) and
+	 * asserts no tag-shaped markup remains. Catches any unencoded `<...>` that
+	 * wp_kses failed to neutralize — including a hypothetical nested tag inside
+	 * a diff span — while tolerating dangerous *words* (onerror, javascript:)
+	 * appearing as inert text inside encoded fragments like `&lt;img ...&gt;`.
 	 */
 	private static function assertOnlyDiffSpansAsLiveHtml( string $sanitized, string $pane_label ): void {
-		$stripped = preg_replace( '#<span class="zw-diff-(?:added|removed)">.*?</span>#s', '', $sanitized );
+		$stripped = preg_replace( '#<span class="zw-diff-(?:added|removed)">|</span>#', '', $sanitized );
 		self::assertIsString( $stripped, 'preg_replace must return a string.' );
 		self::assertDoesNotMatchRegularExpression(
 			'/<[a-zA-Z!?\/]/',

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -165,6 +165,18 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 				'<span class="a"><span class="b"><span class="c">deep</span></span></span>',
 				'deep',
 			),
+			// Unbalanced input: outer disallowed has no matching </span>, so
+			// the paired regex strips the outer up to the inner close and
+			// leaves the inner open as an orphan. Must fail closed via
+			// wp_strip_all_tags rather than return the live inner open tag.
+			'unbalanced outer disallowed leaks inner open if not fail-closed' => array(
+				'<span class="evil"><span class="also-evil">x</span>',
+				'x',
+			),
+			'unbalanced disallowed open with no close at all'                  => array(
+				'<span class="evil">trailing text',
+				'trailing text',
+			),
 		);
 	}
 

--- a/tests/AuditPageFilterParamsTest.php
+++ b/tests/AuditPageFilterParamsTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ZW_TTVGPT_Core\Admin\AuditPage;
+
+#[CoversClass(AuditPage::class)]
+final class AuditPageFilterParamsTest extends TestCase {
+
+	public static function setUpBeforeClass(): void {
+		require_once __DIR__ . '/wp-load-helper.php';
+	}
+
+	/**
+	 * @param array<string, string> $query
+	 */
+	#[DataProvider('nativeMonthProvider')]
+	public function test_get_filter_params_parses_native_month_fallback( array $query, ?int $expected_year, ?int $expected_month ): void {
+		$previous_get = $_GET;
+		$_GET         = $query;
+
+		try {
+			$params = self::invokeGetFilterParams();
+		} finally {
+			$_GET = $previous_get;
+		}
+
+		self::assertSame( $expected_year, $params['year'] );
+		self::assertSame( $expected_month, $params['month'] );
+	}
+
+	/**
+	 * @return array<string, array{array<string, string>, int|null, int|null}>
+	 */
+	public static function nativeMonthProvider(): array {
+		return array(
+			'native YYYYMM value parses into year and month' => array(
+				array( 'm' => '202604' ),
+				2026,
+				4,
+			),
+			'native all-dates zero is a no-op' => array(
+				array( 'm' => '0' ),
+				null,
+				null,
+			),
+			'five digits do not pass anchored YYYYMM regex' => array(
+				array( 'm' => '20264' ),
+				null,
+				null,
+			),
+			'seven digits do not pass anchored YYYYMM regex' => array(
+				array( 'm' => '2026041' ),
+				null,
+				null,
+			),
+			'month zero is outside valid month bounds' => array(
+				array( 'm' => '202600' ),
+				null,
+				null,
+			),
+			'month thirteen is outside valid month bounds' => array(
+				array( 'm' => '202613' ),
+				null,
+				null,
+			),
+			'explicit year and month take precedence over native m' => array(
+				array(
+					'year'  => '2025',
+					'month' => '3',
+					'm'     => '202604',
+				),
+				2025,
+				3,
+			),
+		);
+	}
+
+	/**
+	 * @return array{year: int|null, month: int|null, status_filter: string, change_filter: string, paged: int}
+	 */
+	private static function invokeGetFilterParams(): array {
+		$method = new ReflectionMethod( AuditPage::class, 'get_filter_params' );
+
+		$result = $method->invoke( new AuditPage() );
+		self::assertIsArray( $result );
+
+		return $result;
+	}
+}

--- a/tests/AuditPagePaginationTest.php
+++ b/tests/AuditPagePaginationTest.php
@@ -12,7 +12,7 @@ use ZW_TTVGPT_Core\Admin\AuditPage;
 final class AuditPagePaginationTest extends TestCase {
 
 	/**
-	 * @param array<int, int>                                                                $items
+	 * @param array<int, int> $items
 	 * @param array{slice: array<int, int>, paged: int, total_pages: int, total: int} $expected
 	 */
 	#[DataProvider('paginationProvider')]

--- a/tests/AuditPagePaginationTest.php
+++ b/tests/AuditPagePaginationTest.php
@@ -6,6 +6,7 @@ namespace ZW_TTVGPT_Core\Tests;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use ZW_TTVGPT_Core\Admin\AuditPage;
 
 #[CoversClass(AuditPage::class)]
@@ -17,7 +18,8 @@ final class AuditPagePaginationTest extends TestCase {
 	 */
 	#[DataProvider('paginationProvider')]
 	public function test_paginate_clamps_and_slices( array $items, int $requested_page, int $per_page, array $expected ): void {
-		self::assertSame( $expected, AuditPage::paginate( $items, $requested_page, $per_page ) );
+		$paginate = new ReflectionMethod( AuditPage::class, 'paginate' );
+		self::assertSame( $expected, $paginate->invoke( null, $items, $requested_page, $per_page ) );
 	}
 
 	/**

--- a/tests/AuditPagePaginationTest.php
+++ b/tests/AuditPagePaginationTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZW_TTVGPT_Core\Admin\AuditPage;
+
+#[CoversClass(AuditPage::class)]
+final class AuditPagePaginationTest extends TestCase {
+
+	/**
+	 * @param array<int, int>                                                                $items
+	 * @param array{slice: array<int, int>, paged: int, total_pages: int, total: int} $expected
+	 */
+	#[DataProvider('paginationProvider')]
+	public function test_paginate_clamps_and_slices( array $items, int $requested_page, int $per_page, array $expected ): void {
+		self::assertSame( $expected, AuditPage::paginate( $items, $requested_page, $per_page ) );
+	}
+
+	/**
+	 * @return array<string, array{array<int, int>, int, int, array{slice: array<int, int>, paged: int, total_pages: int, total: int}}>
+	 */
+	public static function paginationProvider(): array {
+		$five = array( 1, 2, 3, 4, 5 );
+		$ten  = array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 );
+
+		return array(
+			'empty list, page 1, per 50'        => array(
+				array(),
+				1,
+				50,
+				array( 'slice' => array(), 'paged' => 1, 'total_pages' => 0, 'total' => 0 ),
+			),
+			'empty list, requested page 5'      => array(
+				array(),
+				5,
+				50,
+				array( 'slice' => array(), 'paged' => 1, 'total_pages' => 0, 'total' => 0 ),
+			),
+			'single page fits exactly'          => array(
+				$five,
+				1,
+				5,
+				array( 'slice' => $five, 'paged' => 1, 'total_pages' => 1, 'total' => 5 ),
+			),
+			'multi-page, first page slice'      => array(
+				$ten,
+				1,
+				4,
+				array( 'slice' => array( 1, 2, 3, 4 ), 'paged' => 1, 'total_pages' => 3, 'total' => 10 ),
+			),
+			'multi-page, middle page slice'     => array(
+				$ten,
+				2,
+				4,
+				array( 'slice' => array( 5, 6, 7, 8 ), 'paged' => 2, 'total_pages' => 3, 'total' => 10 ),
+			),
+			'multi-page, last page short slice' => array(
+				$ten,
+				3,
+				4,
+				array( 'slice' => array( 9, 10 ), 'paged' => 3, 'total_pages' => 3, 'total' => 10 ),
+			),
+			'requested page over total clamps to last' => array(
+				$ten,
+				999,
+				4,
+				array( 'slice' => array( 9, 10 ), 'paged' => 3, 'total_pages' => 3, 'total' => 10 ),
+			),
+			'requested page zero clamps up to 1' => array(
+				$ten,
+				0,
+				4,
+				array( 'slice' => array( 1, 2, 3, 4 ), 'paged' => 1, 'total_pages' => 3, 'total' => 10 ),
+			),
+			'negative requested page clamps up to 1' => array(
+				$ten,
+				-5,
+				4,
+				array( 'slice' => array( 1, 2, 3, 4 ), 'paged' => 1, 'total_pages' => 3, 'total' => 10 ),
+			),
+			'per_page zero produces empty slice but reports total' => array(
+				$five,
+				1,
+				0,
+				array( 'slice' => array(), 'paged' => 1, 'total_pages' => 0, 'total' => 5 ),
+			),
+			'per_page negative produces empty slice' => array(
+				$five,
+				1,
+				-3,
+				array( 'slice' => array(), 'paged' => 1, 'total_pages' => 0, 'total' => 5 ),
+			),
+			'exactly POSTS_PER_PAGE boundary'   => array(
+				range( 1, 50 ),
+				1,
+				50,
+				array( 'slice' => range( 1, 50 ), 'paged' => 1, 'total_pages' => 1, 'total' => 50 ),
+			),
+			'one over POSTS_PER_PAGE boundary'  => array(
+				range( 1, 51 ),
+				2,
+				50,
+				array( 'slice' => array( 51 ), 'paged' => 2, 'total_pages' => 2, 'total' => 51 ),
+			),
+		);
+	}
+}

--- a/tests/HelperApiKeyTest.php
+++ b/tests/HelperApiKeyTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZW_TTVGPT_Core\Helper;
+
+#[CoversClass(Helper::class)]
+final class HelperApiKeyTest extends TestCase {
+
+	#[DataProvider('apiKeyProvider')]
+	public function test_is_valid_api_key( string $input, bool $expected ): void {
+		self::assertSame( $expected, Helper::is_valid_api_key( $input ) );
+	}
+
+	/**
+	 * @return array<string, array{string, bool}>
+	 */
+	public static function apiKeyProvider(): array {
+		return array(
+			'empty string is rejected'        => array( '', false ),
+			'classic sk- key is accepted'     => array( 'sk-AAAAAAAAAAAAAAAAAAAAAAAA', true ),
+			'project key is accepted'         => array( 'sk-proj-ABCDEF1234567890', true ),
+			'service account key is accepted' => array( 'sk-svcacct-ABCDEF1234567890', true ),
+			'admin key is accepted'           => array( 'sk-admin-ABCDEF1234567890', true ),
+			'no prefix is rejected'           => array( 'totally-not-a-key', false ),
+			'uppercase prefix is rejected'    => array( 'SK-AAAAAAAAAAAA', false ),
+			'partial prefix is rejected'      => array( 's-AAAAAAAAAAAA', false ),
+		);
+	}
+}

--- a/tests/HelperApiKeyTest.php
+++ b/tests/HelperApiKeyTest.php
@@ -26,8 +26,8 @@ final class HelperApiKeyTest extends TestCase {
 			'project key is accepted'         => array( 'sk-proj-ABCDEF1234567890', true ),
 			'service account key is accepted' => array( 'sk-svcacct-ABCDEF1234567890', true ),
 			'admin key is accepted'           => array( 'sk-admin-ABCDEF1234567890', true ),
-				// Keep sk-* permissive for future key flavours.
-				'unknown future flavour passes'   => array( 'sk-future-flavor-xyz', true ),
+			// Keep sk-* permissive for future key flavours.
+			'unknown future flavour passes'   => array( 'sk-future-flavor-xyz', true ),
 			'no prefix is rejected'           => array( 'totally-not-a-key', false ),
 			'uppercase prefix is rejected'    => array( 'SK-AAAAAAAAAAAA', false ),
 			'partial prefix is rejected'      => array( 's-AAAAAAAAAAAA', false ),

--- a/tests/HelperApiKeyTest.php
+++ b/tests/HelperApiKeyTest.php
@@ -26,6 +26,9 @@ final class HelperApiKeyTest extends TestCase {
 			'project key is accepted'         => array( 'sk-proj-ABCDEF1234567890', true ),
 			'service account key is accepted' => array( 'sk-svcacct-ABCDEF1234567890', true ),
 			'admin key is accepted'           => array( 'sk-admin-ABCDEF1234567890', true ),
+			// Pin the intentional looseness: anything with the sk- prefix should pass,
+			// so a future OpenAI key flavour does not need a code change to be accepted.
+			'unknown future flavour passes'   => array( 'sk-future-flavor-xyz', true ),
 			'no prefix is rejected'           => array( 'totally-not-a-key', false ),
 			'uppercase prefix is rejected'    => array( 'SK-AAAAAAAAAAAA', false ),
 			'partial prefix is rejected'      => array( 's-AAAAAAAAAAAA', false ),

--- a/tests/HelperApiKeyTest.php
+++ b/tests/HelperApiKeyTest.php
@@ -26,9 +26,8 @@ final class HelperApiKeyTest extends TestCase {
 			'project key is accepted'         => array( 'sk-proj-ABCDEF1234567890', true ),
 			'service account key is accepted' => array( 'sk-svcacct-ABCDEF1234567890', true ),
 			'admin key is accepted'           => array( 'sk-admin-ABCDEF1234567890', true ),
-			// Pin the intentional looseness: anything with the sk- prefix should pass,
-			// so a future OpenAI key flavour does not need a code change to be accepted.
-			'unknown future flavour passes'   => array( 'sk-future-flavor-xyz', true ),
+				// Keep sk-* permissive for future key flavours.
+				'unknown future flavour passes'   => array( 'sk-future-flavor-xyz', true ),
 			'no prefix is rejected'           => array( 'totally-not-a-key', false ),
 			'uppercase prefix is rejected'    => array( 'SK-AAAAAAAAAAAA', false ),
 			'partial prefix is rejected'      => array( 's-AAAAAAAAAAAA', false ),

--- a/tests/HelperWordCountTest.php
+++ b/tests/HelperWordCountTest.php
@@ -37,10 +37,8 @@ final class HelperWordCountTest extends TestCase {
 			'pure numeric is not a word'            => array( '3,5', 0 ),
 			'currency-prefixed number is not a word' => array( '€10', 0 ),
 			'mixed number and word counts the word' => array( '3,5 miljoen', 1 ),
-			// Regression boundaries from investigation: pre-fix str_word_count
-			// reported 120 / 126 here, which exceeded the 100-word retry budget
-			// and triggered up to MAX_RETRY_ATTEMPTS wasted API calls.
-			'regression: 15x diacritic sentence'    => array( str_repeat( 'Het café serveert crème brûlée. ', 15 ), 75 ),
+				// Regression: old str_word_count overcounted these cases and triggered retries.
+				'regression: 15x diacritic sentence'    => array( str_repeat( 'Het café serveert crème brûlée. ', 15 ), 75 ),
 			'regression: 18x em-dash sentence'      => array( str_repeat( 'Bergen op Zoom – Breda blijft bereikbaar. ', 18 ), 108 ),
 		);
 	}

--- a/tests/HelperWordCountTest.php
+++ b/tests/HelperWordCountTest.php
@@ -37,8 +37,8 @@ final class HelperWordCountTest extends TestCase {
 			'pure numeric is not a word'            => array( '3,5', 0 ),
 			'currency-prefixed number is not a word' => array( '€10', 0 ),
 			'mixed number and word counts the word' => array( '3,5 miljoen', 1 ),
-				// Regression: old str_word_count overcounted these cases and triggered retries.
-				'regression: 15x diacritic sentence'    => array( str_repeat( 'Het café serveert crème brûlée. ', 15 ), 75 ),
+			// Regression: old str_word_count overcounted these cases and triggered retries.
+			'regression: 15x diacritic sentence'    => array( str_repeat( 'Het café serveert crème brûlée. ', 15 ), 75 ),
 			'regression: 18x em-dash sentence'      => array( str_repeat( 'Bergen op Zoom – Breda blijft bereikbaar. ', 18 ), 108 ),
 		);
 	}

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -39,11 +39,7 @@ final class RateLimiterTest extends TestCase {
 		self::assertSame( Constants::RATE_LIMIT_MAX_REQUESTS, $GLOBALS['zw_test_transients'][ $key ] );
 	}
 
-	/**
-	 * Regression: at the cap the call must return true *and* must not write,
-	 * because writing refreshes the transient TTL on most cache backends and
-	 * lets a spam-clicking user indefinitely extend their own 60-second lockout.
-	 */
+	/** Regression: blocked requests must not refresh the transient TTL. */
 	public function test_request_at_cap_returns_true_without_refreshing_transient(): void {
 		$key                                   = Constants::get_rate_limit_key( self::USER_ID );
 		$GLOBALS['zw_test_transients'][ $key ] = Constants::RATE_LIMIT_MAX_REQUESTS;

--- a/tests/RecordingLogger.php
+++ b/tests/RecordingLogger.php
@@ -6,10 +6,7 @@ namespace ZW_TTVGPT_Core\Tests;
 use ZW_TTVGPT_Core\Logger;
 
 /**
- * Test double that records error/debug calls instead of writing to error_log.
- *
- * Lets tests assert on logger interactions without depending on WP's logging
- * stack or the global error_log destination.
+ * Test logger that records error/debug calls for assertions.
  */
 final class RecordingLogger extends Logger {
 	/** @var list<array{message: string, context: array<string, mixed>}> */

--- a/tests/SettingsPageConfigTest.php
+++ b/tests/SettingsPageConfigTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ZW_TTVGPT_Core\Admin\SettingsPage;
+use ZW_TTVGPT_Core\Constants;
+
+#[CoversClass(SettingsPage::class)]
+final class SettingsPageConfigTest extends TestCase {
+
+	public function test_legacy_model_toggle_config_shape_is_stable(): void {
+		$reflection = new ReflectionClass( SettingsPage::class );
+		$page       = $reflection->newInstanceWithoutConstructor();
+
+		self::assertSame(
+			array(
+				'fieldName'         => Constants::SETTINGS_OPTION_NAME . '[model]',
+				'legacyOptionValue' => 'legacy-fine-tuned',
+			),
+			$page->get_legacy_model_toggle_config()
+		);
+	}
+}

--- a/tests/SettingsPageSanitizeTest.php
+++ b/tests/SettingsPageSanitizeTest.php
@@ -1,74 +1,48 @@
 <?php
 declare(strict_types=1);
 
-namespace {
-	if ( ! defined( 'ABSPATH' ) ) {
-		exit;
-	}
+namespace ZW_TTVGPT_Core\Tests;
 
-	if ( ! function_exists( 'add_settings_error' ) ) {
-		function add_settings_error( string $setting, string $code, string $message, string $type = 'error' ): void {
-			$GLOBALS['zw_test_settings_errors'][] = array(
-				'setting' => $setting,
-				'code'    => $code,
-				'message' => $message,
-				'type'    => $type,
-			);
-		}
-	}
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ZW_TTVGPT_Core\Admin\SettingsPage;
 
-	if ( ! function_exists( 'get_current_user_id' ) ) {
-		function get_current_user_id(): int {
-			return 123;
-		}
-	}
-
-	if ( ! function_exists( 'wp_cache_delete' ) ) {
-		function wp_cache_delete( string $key, string $group = '' ): bool {
-			return true;
-		}
-	}
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-namespace ZW_TTVGPT_Core\Tests {
+#[CoversClass(SettingsPage::class)]
+final class SettingsPageSanitizeTest extends TestCase {
 
-	use PHPUnit\Framework\Attributes\CoversClass;
-	use PHPUnit\Framework\TestCase;
-	use ReflectionClass;
-	use ZW_TTVGPT_Core\Admin\SettingsPage;
+	public static function setUpBeforeClass(): void {
+		require_once __DIR__ . '/wp-load-helper.php';
+	}
 
-	#[CoversClass(SettingsPage::class)]
-	final class SettingsPageSanitizeTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['zw_test_settings_errors'] = array();
+	}
 
-		public static function setUpBeforeClass(): void {
-			require_once __DIR__ . '/wp-load-helper.php';
-		}
+	public function test_sanitize_settings_does_not_store_invalid_api_key(): void {
+		$logger = new RecordingLogger();
+		$page   = self::newSettingsPage( $logger );
 
-		protected function setUp(): void {
-			$GLOBALS['zw_test_settings_errors'] = array();
-		}
+		$sanitized = $page->sanitize_settings( array( 'api_key' => 'not-an-openai-key' ) );
 
-		public function test_sanitize_settings_does_not_store_invalid_api_key(): void {
-			$logger = new RecordingLogger();
-			$page   = self::newSettingsPage( $logger );
+		self::assertSame( '', $sanitized['api_key'] );
+		self::assertCount( 1, $logger->errors );
+		self::assertSame( 'Invalid OpenAI API key submitted in settings', $logger->errors[0]['message'] );
+		self::assertSame( 123, $logger->errors[0]['context']['user_id'] );
+		self::assertSame( 'invalid_api_key', $GLOBALS['zw_test_settings_errors'][0]['code'] );
+	}
 
-			$sanitized = $page->sanitize_settings( array( 'api_key' => 'not-an-openai-key' ) );
+	private static function newSettingsPage( RecordingLogger $logger ): SettingsPage {
+		$reflection = new ReflectionClass( SettingsPage::class );
+		$page       = $reflection->newInstanceWithoutConstructor();
 
-			self::assertSame( '', $sanitized['api_key'] );
-			self::assertCount( 1, $logger->errors );
-			self::assertSame( 'Invalid OpenAI API key submitted in settings', $logger->errors[0]['message'] );
-			self::assertSame( 123, $logger->errors[0]['context']['user_id'] );
-			self::assertSame( 'invalid_api_key', $GLOBALS['zw_test_settings_errors'][0]['code'] );
-		}
+		$logger_property = $reflection->getProperty( 'logger' );
+		$logger_property->setValue( $page, $logger );
 
-		private static function newSettingsPage( RecordingLogger $logger ): SettingsPage {
-			$reflection = new ReflectionClass( SettingsPage::class );
-			$page       = $reflection->newInstanceWithoutConstructor();
-
-			$logger_property = $reflection->getProperty( 'logger' );
-			$logger_property->setValue( $page, $logger );
-
-			return $page;
-		}
+		return $page;
 	}
 }

--- a/tests/SettingsPageSanitizeTest.php
+++ b/tests/SettingsPageSanitizeTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace {
+	if ( ! function_exists( 'add_settings_error' ) ) {
+		function add_settings_error( string $setting, string $code, string $message, string $type = 'error' ): void {
+			$GLOBALS['zw_test_settings_errors'][] = array(
+				'setting' => $setting,
+				'code'    => $code,
+				'message' => $message,
+				'type'    => $type,
+			);
+		}
+	}
+
+	if ( ! function_exists( 'get_current_user_id' ) ) {
+		function get_current_user_id(): int {
+			return 123;
+		}
+	}
+
+	if ( ! function_exists( 'wp_cache_delete' ) ) {
+		function wp_cache_delete( string $key, string $group = '' ): bool {
+			return true;
+		}
+	}
+}
+
+namespace ZW_TTVGPT_Core\Tests {
+
+	use PHPUnit\Framework\Attributes\CoversClass;
+	use PHPUnit\Framework\TestCase;
+	use ReflectionClass;
+	use ZW_TTVGPT_Core\Admin\SettingsPage;
+
+	#[CoversClass(SettingsPage::class)]
+	final class SettingsPageSanitizeTest extends TestCase {
+
+		public static function setUpBeforeClass(): void {
+			require_once __DIR__ . '/wp-load-helper.php';
+		}
+
+		protected function setUp(): void {
+			$GLOBALS['zw_test_settings_errors'] = array();
+		}
+
+		public function test_sanitize_settings_does_not_store_invalid_api_key(): void {
+			$logger = new RecordingLogger();
+			$page   = self::newSettingsPage( $logger );
+
+			$sanitized = $page->sanitize_settings( array( 'api_key' => 'not-an-openai-key' ) );
+
+			self::assertSame( '', $sanitized['api_key'] );
+			self::assertCount( 1, $logger->errors );
+			self::assertSame( 'Invalid OpenAI API key submitted in settings', $logger->errors[0]['message'] );
+			self::assertSame( 123, $logger->errors[0]['context']['user_id'] );
+			self::assertSame( 'invalid_api_key', $GLOBALS['zw_test_settings_errors'][0]['code'] );
+		}
+
+		private static function newSettingsPage( RecordingLogger $logger ): SettingsPage {
+			$reflection = new ReflectionClass( SettingsPage::class );
+			$page       = $reflection->newInstanceWithoutConstructor();
+
+			$logger_property = $reflection->getProperty( 'logger' );
+			$logger_property->setValue( $page, $logger );
+
+			return $page;
+		}
+	}
+}

--- a/tests/SettingsPageSanitizeTest.php
+++ b/tests/SettingsPageSanitizeTest.php
@@ -2,6 +2,10 @@
 declare(strict_types=1);
 
 namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
+
 	if ( ! function_exists( 'add_settings_error' ) ) {
 		function add_settings_error( string $setting, string $code, string $message, string $type = 'error' ): void {
 			$GLOBALS['zw_test_settings_errors'][] = array(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,8 +1,12 @@
 <?php
 declare(strict_types=1);
 
+// Point ABSPATH at the vendored WordPress install so tests that opt in to the
+// real wp_kses / Text_Diff pipeline can resolve sibling wp-includes/ files via
+// ABSPATH constants the way production code does. Tests that don't load WP
+// only need ABSPATH to be defined to satisfy the source guards.
 if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', __DIR__ . '/' );
+	define( 'ABSPATH', dirname( __DIR__ ) . '/vendor/roots/wordpress-no-content/' );
 }
 
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,6 +44,74 @@ if ( ! function_exists( '__' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( mixed $value, int $flags = 0, int $depth = 512 ): string|false {
+		return json_encode( $value, $flags, $depth );
+	}
+}
+
+if ( ! function_exists( 'admin_url' ) ) {
+	function admin_url( string $path = '', string $scheme = 'admin' ): string {
+		return 'https://example.test/wp-admin/' . $path;
+	}
+}
+
+if ( ! function_exists( 'wp_cache_get' ) ) {
+	function wp_cache_get( string $key, string $group = '', bool $force = false, ?bool &$found = null ): mixed {
+		$found = false;
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_cache_set' ) ) {
+	function wp_cache_set( string $key, mixed $data, string $group = '', int $expire = 0 ): bool {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_cache_delete' ) ) {
+	function wp_cache_delete( string $key, string $group = '' ): bool {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, mixed $default_value = false ): mixed {
+		return $default_value;
+	}
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+	function get_current_user_id(): int {
+		return 123;
+	}
+}
+
+$GLOBALS['zw_test_settings_errors'] = array();
+if ( ! function_exists( 'add_settings_error' ) ) {
+	function add_settings_error( string $setting, string $code, string $message, string $type = 'error' ): void {
+		$GLOBALS['zw_test_settings_errors'][] = array(
+			'setting' => $setting,
+			'code'    => $code,
+			'message' => $message,
+			'type'    => $type,
+		);
+	}
+}
+
+$GLOBALS['zw_test_script_modules'] = array();
+if ( ! function_exists( 'wp_enqueue_script_module' ) ) {
+	function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), mixed $version = false, array $args = array() ): void {
+		$GLOBALS['zw_test_script_modules'][] = array(
+			'id'      => $id,
+			'src'     => $src,
+			'deps'    => $deps,
+			'version' => $version,
+			'args'    => $args,
+		);
+	}
+}
+
 if ( ! class_exists( 'WP_Error' ) ) {
 	class WP_Error {
 		private string $code;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Point ABSPATH at the vendored WordPress install so tests that opt in to the
-// real wp_kses / Text_Diff pipeline can resolve sibling wp-includes/ files via
-// ABSPATH constants the way production code does. Tests that don't load WP
-// only need ABSPATH to be defined to satisfy the source guards.
+// Point ABSPATH at the vendored WordPress install for tests that load WP pieces.
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __DIR__ ) . '/vendor/roots/wordpress-no-content/' );
 }

--- a/tests/wp-load-helper.php
+++ b/tests/wp-load-helper.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Minimal WordPress loader for unit tests that need real wp_kses() and Text_Diff.
+ *
+ * Pulls in just enough of WordPress core (from roots/wordpress-no-content) to
+ * call wp_kses() and run the WP_Text_Diff_Renderer_inline pipeline, without
+ * standing up a database, plugins, or themes. Tests opt in via setUpBeforeClass.
+ */
+
+declare(strict_types=1);
+
+if ( defined( 'ZW_TTVGPT_WP_LOADED' ) ) {
+	return;
+}
+
+$zw_wp_path = dirname( __DIR__ ) . '/vendor/roots/wordpress-no-content/';
+if ( ! is_file( $zw_wp_path . 'wp-includes/kses.php' ) ) {
+	throw new RuntimeException( 'roots/wordpress-no-content is not installed; run composer install --dev.' );
+}
+
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+// kses uses these globals for its allowed-html/entity tables.
+$GLOBALS['wp_filter']            = $GLOBALS['wp_filter'] ?? array();
+$GLOBALS['wp_current_filter']    = $GLOBALS['wp_current_filter'] ?? array();
+$GLOBALS['wp_actions']           = $GLOBALS['wp_actions'] ?? array();
+$GLOBALS['allowedposttags']      = $GLOBALS['allowedposttags'] ?? array();
+$GLOBALS['allowedtags']          = $GLOBALS['allowedtags'] ?? array();
+$GLOBALS['allowedentitynames']   = $GLOBALS['allowedentitynames'] ?? array();
+$GLOBALS['allowedxmlentitynames'] = $GLOBALS['allowedxmlentitynames'] ?? array();
+
+// Order matters: each file pulls helpers from the ones above it.
+require_once $zw_wp_path . 'wp-includes/plugin.php';
+require_once $zw_wp_path . 'wp-includes/formatting.php';
+require_once $zw_wp_path . 'wp-includes/kses.php';
+
+// wp_kses pulls wp_allowed_protocols() from wp-includes/functions.php, but
+// loading functions.php drags in option.php which redeclares get_transient
+// (already stubbed in bootstrap.php). Provide just the one helper we need.
+if ( ! function_exists( 'wp_allowed_protocols' ) ) {
+	function wp_allowed_protocols(): array {
+		return array( 'http', 'https', 'ftp', 'ftps', 'mailto', 'news', 'irc', 'irc6', 'ircs', 'gopher', 'nntp', 'feed', 'telnet', 'mms', 'rtsp', 'sms', 'svn', 'tel', 'fax', 'xmpp', 'webcal', 'urn' );
+	}
+}
+
+// Text_Diff infrastructure used by AuditHelper::generate_word_diff.
+require_once $zw_wp_path . 'wp-includes/Text/Diff.php';
+require_once $zw_wp_path . 'wp-includes/Text/Diff/Engine/native.php';
+require_once $zw_wp_path . 'wp-includes/Text/Diff/Renderer.php';
+require_once $zw_wp_path . 'wp-includes/Text/Diff/Renderer/inline.php';
+require_once $zw_wp_path . 'wp-includes/class-wp-text-diff-renderer-inline.php';
+
+define( 'ZW_TTVGPT_WP_LOADED', true );

--- a/tests/wp-load-helper.php
+++ b/tests/wp-load-helper.php
@@ -33,6 +33,25 @@ $GLOBALS['allowedxmlentitynames'] = $GLOBALS['allowedxmlentitynames'] ?? array()
 
 // Order matters: each file pulls helpers from the ones above it.
 require_once $zw_wp_path . 'wp-includes/plugin.php';
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( mixed $maybeint ): int {
+		return abs( (int) $maybeint );
+	}
+}
+
+if ( ! function_exists( 'is_utf8_charset' ) ) {
+	function is_utf8_charset( ?string $blog_charset = null ): bool {
+		return null === $blog_charset || in_array( strtolower( $blog_charset ), array( 'utf8', 'utf-8' ), true );
+	}
+}
+
+if ( ! function_exists( 'wp_is_valid_utf8' ) ) {
+	function wp_is_valid_utf8( string $text ): bool {
+		return 1 === preg_match( '//u', $text );
+	}
+}
+
 require_once $zw_wp_path . 'wp-includes/formatting.php';
 require_once $zw_wp_path . 'wp-includes/kses.php';
 

--- a/tests/wp-load-helper.php
+++ b/tests/wp-load-helper.php
@@ -1,10 +1,6 @@
 <?php
 /**
- * Minimal WordPress loader for unit tests that need real wp_kses() and Text_Diff.
- *
- * Pulls in just enough of WordPress core (from roots/wordpress-no-content) to
- * call wp_kses() and run the WP_Text_Diff_Renderer_inline pipeline, without
- * standing up a database, plugins, or themes. Tests opt in via setUpBeforeClass.
+ * Loads only the WordPress pieces needed for wp_kses() and Text_Diff tests.
  */
 
 declare(strict_types=1);

--- a/zw-ttvgpt.php
+++ b/zw-ttvgpt.php
@@ -29,7 +29,6 @@ unset( $zw_ttvgpt_plugin_data );
 define( 'ZW_TTVGPT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'ZW_TTVGPT_URL', plugin_dir_url( __FILE__ ) );
 
-// Load Composer autoloader.
 require_once ZW_TTVGPT_DIR . 'vendor/autoload.php';
 
 use ZW_TTVGPT_Core\ApiHandler;
@@ -67,12 +66,9 @@ function zw_ttvgpt_init(): void {
 add_action( 'init', 'zw_ttvgpt_init' );
 
 /**
- * Surfaces a persistent admin notice when ACF is not active.
+ * Shows an admin notice when ACF is missing.
  *
- * Without ACF the AJAX handler short-circuits with an `acf_unavailable` error
- * (see SummaryGenerator::handle_ajax_request). This notice surfaces the same
- * condition up front so admins can fix the dependency before users try to
- * generate summaries, instead of finding out via a failed AJAX response.
+ * This surfaces the dependency before AJAX generation fails with `acf_unavailable`.
  *
  * @since 1.0.0
  */
@@ -95,7 +91,7 @@ function zw_ttvgpt_acf_dependency_notice(): void {
 add_action( 'admin_notices', 'zw_ttvgpt_acf_dependency_notice' );
 
 /**
- * Validates environment and initializes plugin settings on activation.
+ * Initializes plugin settings on activation.
  *
  * @since 1.0.0
  */


### PR DESCRIPTION
## Summary

Final batch from the code review. Stacked on top of #156 (performance); review/merge in order.

Started as inline-script cleanup and grew into a full hardening pass on the audit diff path. All review-feedback rounds (incl. the most recent test/runtime boundary polish) are folded in.

### Diff sanitization (XSS path)
- Narrowed `wp_kses` to `['span' => ['class' => true]]` and added a second-pass class allowlist (`zw-diff-added`, `zw-diff-removed`); anything else is stripped, with `wp_strip_all_tags` as the fail-closed fallback.
- Sanitizer iteration is bounded by the input `<span>` count + 1; fails closed on PCRE error, orphan disallowed `<span>` opens, or stability overflow.
- `<span` matcher made case-insensitive so the regex bound and content match agree.

### Audit content
- `strip_region_prefix` switched from ASCII `[A-Z]` to Unicode `\p{Lu}` so accented uppercase prefixes (`CURAÇAO`, `ZÜRICH`) get stripped. Regression covered.
- PCRE failure sites in `AuditHelper` (split, diff-class strip, whitespace normalize, region prefix) fail closed with safe fallbacks. The standalone telemetry helper (action hook + `error_log` from a static class) was removed in the final polish round.

### Inline scripts to ES modules
- Settings page legacy fine-tuned-model toggle moved to `assets/settings.js`; `AdminMenu` enqueues it plus an inline config blob on the settings hook (same pattern as post-edit).
- Audit page filter handler moved to `assets/audit.js` using vanilla `URLSearchParams`; drops the last jQuery dependency.

### Settings sanitization
- `is_valid_api_key` reframed in its docblock as a liveness check, not format validation (OpenAI keys shift: `sk-`, `sk-proj-`, `sk-svcacct-`, `sk-admin-`).
- Sanitizer now drops invalid API keys from saved settings instead of round-tripping bad input.

### Test/runtime boundaries
- `AuditPage::paginate()` is now `private static`; test reaches it via `ReflectionMethod` instead of exposing public API for testability.
- `roots/wordpress-no-content` constraint aligned with the plugin's declared `Requires at least: 6.8`.
- Added `HelperApiKeyTest`, `AuditHelperRegionPrefixTest`, `AuditPagePaginationTest`, `AuditPageDiffAllowlistTest`, `AuditPageFilterParamsTest`, `AdminMenuInlineConfigTest`, `SettingsPageSanitizeTest`. 18 to 120 tests, pure-function plus a WP-light bootstrap.

## Test plan

- [x] `vendor/bin/phpcs`: clean
- [x] `vendor/bin/phpstan analyse`: clean
- [x] `npm run lint`: clean
- [x] `vendor/bin/phpunit`: 120/120
- [ ] Manual: open settings page, switch model to a legacy `ft:`-model, confirm the text input appears and is required
- [ ] Manual: open audit page, change a filter dropdown, confirm the URL rebuilds without jQuery
- [ ] Manual: open a diff modal on an AI-edited post and confirm spans render correctly