### PR TITLE
fix: simplify audit diff sanitizer

### DIFF
--- a/assets/audit.css
+++ b/assets/audit.css
@@ -60,15 +60,16 @@
     border-left: 4px solid #00a0d2;
 }
 
-.zw-diff-added {
+.zw-diff-panel ins {
     padding: 2px 4px;
     font-weight: 500;
     color: #155724;
+    text-decoration: none;
     background: #d4edda;
     border-radius: 3px;
 }
 
-.zw-diff-removed {
+.zw-diff-panel del {
     padding: 2px 4px;
     font-weight: 500;
     color: #721c24;

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -21,9 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since   1.0.0
  */
 class AuditHelper {
-	private const string DIFF_CLASS_ADDED   = 'zw-diff-added';
-	private const string DIFF_CLASS_REMOVED = 'zw-diff-removed';
-
 	/**
 	 * Splits content for Text_Diff. Returns the unsplit text on PCRE failure so
 	 * the caller still renders something instead of an empty diff.
@@ -41,14 +38,15 @@ class AuditHelper {
 	}
 
 	/**
-	 * Strips spans of the given diff class. Returns null on PCRE failure so the
+	 * Strips the given inline diff tag. Returns null on PCRE failure so the
 	 * caller can fall back to a plain-text pane.
 	 *
-	 * @param string $diff_html  Combined diff HTML.
-	 * @param string $class_name Diff class to remove.
+	 * @param string $diff_html Combined diff HTML.
+	 * @param string $tag_name  Inline diff tag name to remove.
 	 */
-	private static function remove_diff_class( string $diff_html, string $class_name ): ?string {
-		$pattern = '/<span class="' . preg_quote( $class_name, '/' ) . '">.*?<\/span>/s';
+	private static function remove_diff_tag( string $diff_html, string $tag_name ): ?string {
+		$tag     = preg_quote( $tag_name, '/' );
+		$pattern = '/<' . $tag . '\b[^>]*>.*?<\/' . $tag . '>/is';
 		$result  = preg_replace( $pattern, '', $diff_html );
 
 		return null === $result ? null : $result;
@@ -355,21 +353,9 @@ class AuditHelper {
 		$renderer  = new \WP_Text_Diff_Renderer_inline();
 		$diff_html = $renderer->render( $text_diff );
 
-		// WordPress uses <ins> and <del>, convert to our classes.
-		$diff_html = str_replace(
-			array( '<ins>', '</ins>', '<del>', '</del>' ),
-			array(
-				'<span class="' . self::DIFF_CLASS_ADDED . '">',
-				'</span>',
-				'<span class="' . self::DIFF_CLASS_REMOVED . '">',
-				'</span>',
-			),
-			$diff_html
-		);
-
 		// Split the diff into before/after by removing the opposite tags.
-		$before = self::remove_diff_class( $diff_html, self::DIFF_CLASS_ADDED );
-		$after  = self::remove_diff_class( $diff_html, self::DIFF_CLASS_REMOVED );
+		$before = self::remove_diff_tag( $diff_html, 'ins' );
+		$after  = self::remove_diff_tag( $diff_html, 'del' );
 
 		if ( null === $before || null === $after ) {
 			return self::plain_diff_result( $old_clean, $modified_clean );

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -22,6 +22,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class AuditHelper {
 	/**
+	 * Logs a PCRE failure without including article content.
+	 *
+	 * @param string $operation Operation that triggered the PCRE failure.
+	 */
+	private static function log_pcre_failure( string $operation ): void {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Design choice for rare PCRE regression visibility.
+		error_log( sprintf( 'ZW_TTVGPT.ERROR: Audit diff PCRE failure during %s: %s', $operation, preg_last_error_msg() ) );
+	}
+
+	/**
 	 * Splits content for Text_Diff. Returns the unsplit text on PCRE failure so
 	 * the caller still renders something instead of an empty diff.
 	 *
@@ -31,6 +41,7 @@ class AuditHelper {
 	private static function split_for_word_diff( string $content ): array {
 		$parts = preg_split( '/([.!?]\s+)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
 		if ( false === $parts ) {
+			self::log_pcre_failure( 'split_for_word_diff' );
 			return '' === $content ? array() : array( $content );
 		}
 
@@ -49,6 +60,10 @@ class AuditHelper {
 		$pattern = '/<' . $tag . '\b[^>]*>.*?<\/' . $tag . '>/is';
 		$result  = preg_replace( $pattern, '', $diff_html );
 
+		if ( null === $result ) {
+			self::log_pcre_failure( 'remove_diff_tag' );
+		}
+
 		return null === $result ? null : $result;
 	}
 
@@ -59,6 +74,10 @@ class AuditHelper {
 	 */
 	private static function normalize_diff_whitespace( string $diff_html ): string {
 		$normalized = preg_replace( '/\s+/', ' ', $diff_html );
+
+		if ( null === $normalized ) {
+			self::log_pcre_failure( 'normalize_diff_whitespace' );
+		}
 
 		return null === $normalized ? $diff_html : $normalized;
 	}

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -43,6 +43,22 @@ class AdminMenu {
 
 		add_action( 'admin_menu', $this->add_admin_menu( ... ) );
 		add_action( 'admin_enqueue_scripts', $this->enqueue_admin_assets( ... ) );
+		add_action( 'zw_ttvgpt_diff_sanitizer_failed', $this->log_diff_sanitizer_failure( ... ), 10, 2 );
+	}
+
+	/**
+	 * Logs sanitizer failures reported by the audit diff panel.
+	 *
+	 * @param string $reason        Stable failure reason.
+	 * @param string $error_message Optional lower-level error message.
+	 */
+	private function log_diff_sanitizer_failure( string $reason, string $error_message = '' ): void {
+		$context = array( 'reason' => $reason );
+		if ( '' !== $error_message ) {
+			$context['error_message'] = $error_message;
+		}
+
+		$this->logger->error( 'Diff sanitizer failed', $context );
 	}
 
 	/**

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -101,7 +101,10 @@ class AuditPage {
 	/**
 	 * Reports a sanitizer failure without leaking diff content.
 	 *
-	 * @param string $reason        Stable reason code.
+	 * The hook is retained for the current non-string guard and any future
+	 * sanitizer failure modes that need the same logging/subscriber path.
+	 *
+	 * @param string $reason        Stable reason code for this failure mode.
 	 * @param string $error_message Optional lower-level error message.
 	 */
 	private static function report_diff_sanitizer_failure( string $reason, string $error_message = '' ): void {
@@ -111,8 +114,8 @@ class AuditPage {
 	}
 
 	/**
-	 * Runs wp_kses across the pre_kses filter, which can return arbitrary
-	 * values; the caller must guard before echoing the result.
+	 * Runs wp_kses(), including pre_kses callbacks that can return arbitrary
+	 * values. Callers must verify is_string() before echoing the result.
 	 *
 	 * @param string $diff_html Raw diff HTML.
 	 */

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -63,12 +63,13 @@ class AuditPage {
 	private const int POSTS_PER_PAGE = 50;
 
 	/**
-	 * Keep in sync with generate_word_diff() and DIFF_ALLOWED_CLASSES.
+	 * Allowed tag/attribute map for diff panel wp_kses.
 	 *
 	 * @var array<string, array<string, bool>>
 	 */
 	private const array DIFF_ALLOWED_TAGS = array(
-		'span' => array( 'class' => true ),
+		'ins' => array(),
+		'del' => array(),
 	);
 
 	/**
@@ -98,13 +99,6 @@ class AuditPage {
 	}
 
 	/**
-	 * Diff class names emitted by AuditHelper::generate_word_diff().
-	 *
-	 * @var array<int, string>
-	 */
-	private const array DIFF_ALLOWED_CLASSES = array( 'zw-diff-added', 'zw-diff-removed' );
-
-	/**
 	 * Reports a sanitizer failure without leaking diff content.
 	 *
 	 * @param string $reason        Stable reason code.
@@ -118,7 +112,7 @@ class AuditPage {
 
 	/**
 	 * Runs wp_kses across the pre_kses filter, which can return arbitrary
-	 * values; the caller must guard before handing the result to PCRE.
+	 * values; the caller must guard before echoing the result.
 	 *
 	 * @param string $diff_html Raw diff HTML.
 	 */
@@ -129,10 +123,8 @@ class AuditPage {
 	/**
 	 * Sanitizes diff HTML for the audit modal.
 	 *
-	 * Because wp_kses() accepts any class value when class is in the allowlist,
-	 * this adds a pass that keeps only the plugin's diff classes and converts
-	 * other span markup to inert text. Fails closed by stripping remaining tags
-	 * on any sign of malformed or untrusted output.
+	 * The diff renderer emits unadorned <ins>/<del> tags. Letting wp_kses()
+	 * keep only those tags avoids a class allowlist and strips any attributes.
 	 *
 	 * @param string $diff_html Raw diff HTML emitted by AuditHelper::generate_word_diff.
 	 */
@@ -143,57 +135,7 @@ class AuditPage {
 			return wp_strip_all_tags( $diff_html );
 		}
 
-		// DIFF_ALLOWED_CLASSES is constant, so build the predicate once per process.
-		static $paired_pattern = null;
-		static $open_pattern   = null;
-		if ( null === $paired_pattern ) {
-			$class_pattern   = implode(
-				'|',
-				array_map(
-					static fn ( string $class_name ): string => preg_quote( $class_name, '#' ),
-					self::DIFF_ALLOWED_CLASSES
-				)
-			);
-			$disallowed_open = '<(?i:span)(?![^>]*\b(?i:class)=(["\'])\s*(?:' . $class_pattern . ')\s*\1)[^>]*>';
-			$paired_pattern  = '#' . $disallowed_open . '(.*?)</(?i:span)>#s';
-			$open_pattern    = '#' . $disallowed_open . '#';
-		}
-
-		// Bound iteration to the number of input spans, plus one stability check.
-		$span_count = preg_match_all( '/<span\b/i', $kses_out );
-		if ( false === $span_count ) {
-			self::report_diff_sanitizer_failure( 'span_count_regex_failed', preg_last_error_msg() );
-			return wp_strip_all_tags( $kses_out );
-		}
-		$max_iterations = $span_count + 1;
-
-		$current = $kses_out;
-		for ( $i = 0; $i < $max_iterations; $i++ ) {
-			$next = preg_replace( $paired_pattern, '$2', $current );
-			if ( null === $next ) {
-				self::report_diff_sanitizer_failure( 'paired_regex_failed', preg_last_error_msg() );
-				return wp_strip_all_tags( $current );
-			}
-			if ( $next === $current ) {
-				// Stable, but the paired regex can only strip balanced
-				// disallowed spans. If a disallowed open survived without a
-				// matching close, fail closed rather than echo live markup.
-				$open_match = preg_match( $open_pattern, $current );
-				if ( false === $open_match ) {
-					self::report_diff_sanitizer_failure( 'open_regex_failed', preg_last_error_msg() );
-					return wp_strip_all_tags( $current );
-				}
-				if ( 1 === $open_match ) {
-					self::report_diff_sanitizer_failure( 'orphan_disallowed_span' );
-					return wp_strip_all_tags( $current );
-				}
-				return $current;
-			}
-			$current = $next;
-		}
-
-		self::report_diff_sanitizer_failure( 'iteration_cap_exceeded' );
-		return wp_strip_all_tags( $current );
+		return $kses_out;
 	}
 
 	/**
@@ -700,7 +642,7 @@ class AuditPage {
 									<h3 class="hndle"><?php esc_html_e( 'AI-versie', 'zw-ttvgpt' ); ?></h3>
 								</div>
 								<div class="inside">
-									<div style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
+									<div class="zw-diff-panel" style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
 										<?php
 											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is sanitized by sanitize_diff_panel().
 											echo self::sanitize_diff_panel( $diff['before'] );
@@ -714,7 +656,7 @@ class AuditPage {
 									<h3 class="hndle"><?php esc_html_e( 'Bewerkte versie', 'zw-ttvgpt' ); ?></h3>
 								</div>
 								<div class="inside">
-									<div style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
+									<div class="zw-diff-panel" style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
 										<?php
 											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is sanitized by sanitize_diff_panel().
 											echo self::sanitize_diff_panel( $diff['after'] );

--- a/tests/AdminMenuInlineConfigTest.php
+++ b/tests/AdminMenuInlineConfigTest.php
@@ -51,6 +51,11 @@ namespace ZW_TTVGPT_Core\Tests {
 
 		protected function setUp(): void {
 			$GLOBALS['zw_test_script_modules'] = array();
+			remove_all_actions( 'zw_ttvgpt_diff_sanitizer_failed' );
+		}
+
+		protected function tearDown(): void {
+			remove_all_actions( 'zw_ttvgpt_diff_sanitizer_failed' );
 		}
 
 		public function test_settings_module_is_not_enqueued_when_inline_config_encoding_fails(): void {
@@ -73,6 +78,23 @@ namespace ZW_TTVGPT_Core\Tests {
 
 			self::assertSame( 'zw-ttvgpt-settings', $GLOBALS['zw_test_script_modules'][0]['id'] );
 			self::assertSame( array(), $logger->errors );
+		}
+
+		public function test_diff_sanitizer_failure_hook_is_logged(): void {
+			$logger = new RecordingLogger();
+
+			new AdminMenu( $logger );
+			do_action( 'zw_ttvgpt_diff_sanitizer_failed', 'wp_kses_non_string', 'pre_kses returned array' );
+
+			self::assertCount( 1, $logger->errors );
+			self::assertSame( 'Diff sanitizer failed', $logger->errors[0]['message'] );
+			self::assertSame(
+				array(
+					'reason'        => 'wp_kses_non_string',
+					'error_message' => 'pre_kses returned array',
+				),
+				$logger->errors[0]['context']
+			);
 		}
 
 		private static function newAdminMenu( RecordingLogger $logger, SettingsPage $settings_page ): AdminMenu {

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -80,7 +80,12 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 	}
 
 	public function test_generate_word_diff_falls_back_to_plain_text_when_diff_stripping_regex_fails(): void {
-		$previous_limit = ini_set( 'pcre.backtrack_limit', '1' );
+		$log_file           = tempnam( sys_get_temp_dir(), 'zw-ttvgpt-pcre-' );
+		$previous_error_log = false;
+		self::assertIsString( $log_file );
+
+		$previous_error_log = ini_set( 'error_log', $log_file );
+		$previous_limit     = ini_set( 'pcre.backtrack_limit', '1' );
 
 		try {
 			$diff = AuditHelper::generate_word_diff( 'oude zin', 'nieuwe zin' );
@@ -88,10 +93,22 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 			if ( false !== $previous_limit ) {
 				ini_set( 'pcre.backtrack_limit', $previous_limit );
 			}
+			if ( false !== $previous_error_log ) {
+				ini_set( 'error_log', $previous_error_log );
+			}
 		}
 
 		self::assertSame( 'oude zin', $diff['before'] );
 		self::assertSame( 'nieuwe zin', $diff['after'] );
 		self::assertNotSame( $diff['before'], $diff['after'], 'PCRE failures must not show the combined diff in both panes.' );
+
+		$log_contents = file_get_contents( $log_file );
+		self::assertIsString( $log_contents );
+		self::assertStringContainsString( 'Audit diff PCRE failure during remove_diff_tag', $log_contents );
+		self::assertStringContainsString( 'Backtrack limit exhausted', $log_contents );
+
+		if ( is_file( $log_file ) ) {
+			unlink( $log_file );
+		}
 	}
 }

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -23,13 +23,16 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	 *
 	 * @var array<string, array<string, bool>>
 	 */
-	private const array EXPECTED_ALLOWLIST = array( 'span' => array( 'class' => true ) );
+	private const array EXPECTED_ALLOWLIST = array(
+		'ins' => array(),
+		'del' => array(),
+	);
 
 	public static function setUpBeforeClass(): void {
 		require_once __DIR__ . '/wp-load-helper.php';
 	}
 
-	public function test_diff_allowlist_constant_only_permits_span_with_class(): void {
+	public function test_diff_allowlist_constant_only_permits_ins_and_del_without_attributes(): void {
 		$reflection = new ReflectionClass( AuditPage::class );
 		$constant   = $reflection->getReflectionConstant( 'DIFF_ALLOWED_TAGS' );
 
@@ -48,23 +51,23 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 		$sanitized_before = AuditPage::sanitize_diff_panel( $diff['before'] );
 		$sanitized_after  = AuditPage::sanitize_diff_panel( $diff['after'] );
 
-		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_before, 'BEFORE pane' );
-		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_after, 'AFTER pane' );
+		self::assertOnlyDiffTagsAsLiveHtml( $sanitized_before, 'BEFORE pane' );
+		self::assertOnlyDiffTagsAsLiveHtml( $sanitized_after, 'AFTER pane' );
 	}
 
 	/**
-	 * Asserts that only plugin diff spans remain as live HTML.
+	 * Asserts that only inline diff tags remain as live HTML.
 	 *
 	 * @param string $sanitized Sanitized HTML.
 	 * @param string $pane_label Assertion label.
 	 */
-	private static function assertOnlyDiffSpansAsLiveHtml( string $sanitized, string $pane_label ): void {
-		$stripped = preg_replace( '#<span class="zw-diff-(?:added|removed)">|</span>#', '', $sanitized );
+	private static function assertOnlyDiffTagsAsLiveHtml( string $sanitized, string $pane_label ): void {
+		$stripped = preg_replace( '#</?(?:ins|del)>#', '', $sanitized );
 		self::assertIsString( $stripped, 'preg_replace must return a string.' );
 		self::assertDoesNotMatchRegularExpression(
 			'/<[a-zA-Z!?\/]/',
 			$stripped,
-			sprintf( 'Live HTML markup other than diff spans survived in %s: %s', $pane_label, $sanitized )
+			sprintf( 'Live HTML markup other than diff tags survived in %s: %s', $pane_label, $sanitized )
 		);
 	}
 
@@ -91,7 +94,7 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	#[DataProvider('rawSanitizerProvider')]
 	public function test_sanitize_diff_panel_strips_unencoded_markup( string $raw_input ): void {
 		$sanitized = AuditPage::sanitize_diff_panel( $raw_input );
-		self::assertOnlyDiffSpansAsLiveHtml( $sanitized, 'direct helper input' );
+		self::assertOnlyDiffTagsAsLiveHtml( $sanitized, 'direct helper input' );
 	}
 
 	/**
@@ -99,28 +102,25 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	 */
 	public static function rawSanitizerProvider(): array {
 		return array(
-			'raw script tag bypasses Text_Diff escaping'   => array( '<span class="zw-diff-added">ok</span><script>alert(1)</script>' ),
-			'raw img onerror bypasses Text_Diff escaping'  => array( '<img src=x onerror="alert(1)"><span class="zw-diff-added">ok</span>' ),
-			'raw iframe bypasses Text_Diff escaping'       => array( '<iframe src="https://evil.example/"></iframe><span class="zw-diff-removed">x</span>' ),
-			'raw javascript: anchor'                       => array( '<a href="javascript:alert(1)">klik</a>' ),
-			'nested script inside diff span'               => array( '<span class="zw-diff-added">ok<script>alert(1)</script></span>' ),
-			// wp_kses allows class values; the helper must enforce the allowlist.
-			'span with non-diff class'                     => array( '<span class="evil">x</span>' ),
-			'span with non-diff class plus legit diff'     => array( '<span class="evil">x</span><span class="zw-diff-added">ok</span>' ),
-			'span with extra class alongside diff class'   => array( '<span class="zw-diff-added evil">x</span>' ),
-			'span with no class attribute at all'          => array( '<span>x</span><span class="zw-diff-added">ok</span>' ),
-			'span with single-quoted non-diff class'       => array( "<span class='evil'>x</span>" ),
+			'raw script tag bypasses Text_Diff escaping'  => array( '<ins>ok</ins><script>alert(1)</script>' ),
+			'raw img onerror bypasses Text_Diff escaping' => array( '<img src=x onerror="alert(1)"><ins>ok</ins>' ),
+			'raw iframe bypasses Text_Diff escaping'      => array( '<iframe src="https://evil.example/"></iframe><del>x</del>' ),
+			'raw javascript: anchor'                      => array( '<a href="javascript:alert(1)">klik</a>' ),
+			'nested script inside diff tag'               => array( '<ins>ok<script>alert(1)</script></ins>' ),
+			'span with former diff class'                 => array( '<span class="zw-diff-added">x</span>' ),
+			'ins with class and event handler'            => array( '<ins class="evil" onclick="alert(1)">x</ins>' ),
+			'del with custom data attribute'              => array( '<del data-old="1">x</del>' ),
 		);
 	}
 
-	public function test_legitimate_diff_spans_survive_sanitization(): void {
+	public function test_legitimate_diff_tags_survive_sanitization(): void {
 		$diff = AuditHelper::generate_word_diff( 'het originele bericht hier', 'het bewerkte bericht hier' );
 
 		$sanitized_before = AuditPage::sanitize_diff_panel( $diff['before'] );
 		$sanitized_after  = AuditPage::sanitize_diff_panel( $diff['after'] );
 
-		self::assertStringContainsString( '<span class="zw-diff-removed"', $sanitized_before, 'Removed-content spans must survive sanitization.' );
-		self::assertStringContainsString( '<span class="zw-diff-added"', $sanitized_after, 'Added-content spans must survive sanitization.' );
+		self::assertStringContainsString( '<del>', $sanitized_before, 'Removed-content tags must survive sanitization.' );
+		self::assertStringContainsString( '<ins>', $sanitized_after, 'Added-content tags must survive sanitization.' );
 		self::assertStringContainsString( 'bericht', $sanitized_before );
 		self::assertStringContainsString( 'bericht', $sanitized_after );
 	}
@@ -141,28 +141,27 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	 */
 	public static function strictSanitizerProvider(): array {
 		return array(
-			'nested disallowed spans (both stripped, no orphan markup)' => array(
-				'<span class="evil"><span class="also-evil">x</span></span>',
+			'ins attributes are stripped'                  => array(
+				'<ins class="zw-diff-added" onclick="alert(1)">x</ins>',
+				'<ins>x</ins>',
+			),
+			'del attributes are stripped'                  => array(
+				'<del data-old="1">x</del>',
+				'<del>x</del>',
+			),
+			'former diff span is inert text'               => array(
+				'<span class="zw-diff-added">x</span>',
 				'x',
 			),
-			'multi-class value is not a partial allowlist match' => array(
-				'<span class="zw-diff-added evil">x</span>',
-				'x',
-			),
-			'entity-encoded class does not decode into allowlist' => array(
-				'<span class="zw-diff-&#x61;dded">x</span>',
-				'x',
+			'nested script inside allowed tag is inert text' => array(
+				'<ins>ok<script>alert(1)</script></ins>',
+				'<ins>okalert(1)</ins>',
 			),
 			'three-deep disallowed nesting collapses to text' => array(
 				'<span class="a"><span class="b"><span class="c">deep</span></span></span>',
 				'deep',
 			),
-			// Malformed nesting must fail closed instead of returning an orphan span.
-			'unbalanced outer disallowed leaks inner open if not fail-closed' => array(
-				'<span class="evil"><span class="also-evil">x</span>',
-				'x',
-			),
-			'unbalanced disallowed open with no close at all'                  => array(
+			'unbalanced disallowed open with no close at all' => array(
 				'<span class="evil">trailing text',
 				'trailing text',
 			),
@@ -170,7 +169,7 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	}
 
 	/**
-	 * Guards against fixed iteration caps that could return live disallowed spans.
+	 * Guards against returning live disallowed tags.
 	 *
 	 * @param int $depth Nesting depth.
 	 */
@@ -180,7 +179,7 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 		$output = AuditPage::sanitize_diff_panel( $input );
 
 		self::assertSame( 'x', $output, sprintf( 'Depth %d must collapse to inert text.', $depth ) );
-		self::assertOnlyDiffSpansAsLiveHtml( $output, sprintf( 'depth %d output', $depth ) );
+		self::assertOnlyDiffTagsAsLiveHtml( $output, sprintf( 'depth %d output', $depth ) );
 	}
 
 	/**
@@ -188,9 +187,9 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	 */
 	public static function deepNestingDepthProvider(): array {
 		return array(
-			'21 deep (just past the old fixed cap)' => array( 21 ),
-			'25 deep'                               => array( 25 ),
-			'50 deep'                               => array( 50 ),
+			'21 deep' => array( 21 ),
+			'25 deep' => array( 25 ),
+			'50 deep' => array( 50 ),
 		);
 	}
 
@@ -202,40 +201,8 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 
 		self::assertStringContainsString( '&lt;', $sanitized_before, 'Literal `<` from user text must survive as entity in BEFORE pane.' );
 		self::assertStringContainsString( '&lt;', $sanitized_after, 'Literal `<` from user text must survive as entity in AFTER pane.' );
-		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_before, 'BEFORE pane' );
-		self::assertOnlyDiffSpansAsLiveHtml( $sanitized_after, 'AFTER pane' );
-	}
-
-	public function test_sanitize_diff_panel_reports_orphan_disallowed_open_fail_closed(): void {
-		$events = array();
-
-		add_action(
-			'zw_ttvgpt_diff_sanitizer_failed',
-			static function ( string $reason, string $error_message ) use ( &$events ): void {
-				$events[] = array(
-					'reason'  => $reason,
-					'message' => $error_message,
-				);
-			},
-			10,
-			2
-		);
-
-		try {
-			self::assertSame( 'trailing text', AuditPage::sanitize_diff_panel( '<span class="evil">trailing text' ) );
-		} finally {
-			remove_all_actions( 'zw_ttvgpt_diff_sanitizer_failed' );
-		}
-
-		self::assertSame(
-			array(
-				array(
-					'reason'  => 'orphan_disallowed_span',
-					'message' => '',
-				),
-			),
-			$events
-		);
+		self::assertOnlyDiffTagsAsLiveHtml( $sanitized_before, 'BEFORE pane' );
+		self::assertOnlyDiffTagsAsLiveHtml( $sanitized_after, 'AFTER pane' );
 	}
 
 	public function test_sanitize_diff_panel_fails_closed_when_kses_filter_returns_non_string(): void {
@@ -260,7 +227,7 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 		);
 
 		try {
-			self::assertSame( 'x', AuditPage::sanitize_diff_panel( '<span class="evil">x</span>' ) );
+			self::assertSame( 'x', AuditPage::sanitize_diff_panel( '<ins>x</ins>' ) );
 		} finally {
 			remove_all_filters( 'pre_kses' );
 			remove_all_actions( 'zw_ttvgpt_diff_sanitizer_failed' );

--- a/tests/AuditPageDiffAllowlistTest.php
+++ b/tests/AuditPageDiffAllowlistTest.php
@@ -187,9 +187,7 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 	 */
 	public static function deepNestingDepthProvider(): array {
 		return array(
-			'21 deep' => array( 21 ),
-			'25 deep' => array( 25 ),
-			'50 deep' => array( 50 ),
+			'representative deep nesting' => array( 50 ),
 		);
 	}
 
@@ -201,6 +199,27 @@ final class AuditPageDiffAllowlistTest extends TestCase {
 
 		self::assertStringContainsString( '&lt;', $sanitized_before, 'Literal `<` from user text must survive as entity in BEFORE pane.' );
 		self::assertStringContainsString( '&lt;', $sanitized_after, 'Literal `<` from user text must survive as entity in AFTER pane.' );
+		self::assertOnlyDiffTagsAsLiveHtml( $sanitized_before, 'BEFORE pane' );
+		self::assertOnlyDiffTagsAsLiveHtml( $sanitized_after, 'AFTER pane' );
+	}
+
+	public function test_literal_diff_tags_from_user_content_render_as_entities(): void {
+		$diff = AuditHelper::generate_word_diff(
+			'literal <ins>evil</ins> en <del>weg</del> oud',
+			'literal <ins>evil</ins> en <del>weg</del> nieuw'
+		);
+
+		$sanitized_before = AuditPage::sanitize_diff_panel( $diff['before'] );
+		$sanitized_after  = AuditPage::sanitize_diff_panel( $diff['after'] );
+
+		self::assertStringContainsString( '&lt;ins&gt;evil&lt;/ins&gt;', $sanitized_before );
+		self::assertStringContainsString( '&lt;del&gt;weg&lt;/del&gt;', $sanitized_before );
+		self::assertStringContainsString( '&lt;ins&gt;evil&lt;/ins&gt;', $sanitized_after );
+		self::assertStringContainsString( '&lt;del&gt;weg&lt;/del&gt;', $sanitized_after );
+		self::assertStringNotContainsString( '<ins>evil</ins>', $sanitized_before );
+		self::assertStringNotContainsString( '<ins>evil</ins>', $sanitized_after );
+		self::assertStringNotContainsString( '<del>weg</del>', $sanitized_before );
+		self::assertStringNotContainsString( '<del>weg</del>', $sanitized_after );
 		self::assertOnlyDiffTagsAsLiveHtml( $sanitized_before, 'BEFORE pane' );
 		self::assertOnlyDiffTagsAsLiveHtml( $sanitized_after, 'AFTER pane' );
 	}


### PR DESCRIPTION
## Summary
- keep WordPress inline diff <ins>/<del> tags instead of converting them to styled spans
- simplify audit diff sanitization to wp_kses allowlisting for <ins>/<del> without attributes
- update audit diff CSS and sanitizer coverage for the native tags

Fixes #161.

## Testing
- vendor/bin/phpunit
- npm run lint
- vendor/bin/phpcs
- vendor/bin/phpstan analyse --memory-limit=1G