### PR TITLE
chore: recover audit cleanup leftovers

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -153,8 +153,6 @@ function injectGenerateButton() {
     button.addEventListener('click', handleGenerateClick);
 
     cachedAcfField.addEventListener('input', updateWordCounter);
-    cachedAcfField.addEventListener('change', updateWordCounter);
-    cachedAcfField.addEventListener('keyup', updateWordCounter);
 
     updateWordCounter();
 }

--- a/assets/audit.js
+++ b/assets/audit.js
@@ -13,7 +13,7 @@ if (!config) {
 
     function applyFilters() {
         const params = new URLSearchParams();
-        params.set('page', 'zw-ttvgpt-audit');
+        params.set('page', config.pageSlug);
 
         const dateValue = date?.value ?? '';
         if (dateValue && dateValue !== '0') {

--- a/includes/Constants.php
+++ b/includes/Constants.php
@@ -46,6 +46,14 @@ class Constants {
 	public const string SETTINGS_PAGE_SLUG = 'zw-ttvgpt-settings';
 
 	/**
+	 * Page slug for plugin audit page.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	public const string AUDIT_PAGE_SLUG = 'zw-ttvgpt-audit';
+
+	/**
 	 * Capability required to access plugin settings.
 	 *
 	 * @since 1.0.0

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -63,7 +63,7 @@ class AdminMenu {
 			__( 'Tekst TV Audit', 'zw-ttvgpt' ),
 			__( 'Tekst TV Audit', 'zw-ttvgpt' ),
 			Constants::REQUIRED_CAPABILITY,
-			'zw-ttvgpt-audit',
+			Constants::AUDIT_PAGE_SLUG,
 			array( new AuditPage(), 'render' )
 		);
 	}
@@ -79,10 +79,14 @@ class AdminMenu {
 		$version = Helper::get_asset_version();
 
 		// Inline config prints before the deferred module tags read window.zwTTVGPT*.
-		if ( 'tools_page_zw-ttvgpt-audit' === $hook ) {
+		if ( 'tools_page_' . Constants::AUDIT_PAGE_SLUG === $hook ) {
 			wp_enqueue_style( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.css', array(), $version );
 
-			if ( $this->print_inline_config( 'zwTTVGPTAudit', array( 'baseUrl' => admin_url( 'tools.php' ) ) ) ) {
+			$audit_config = array(
+				'baseUrl'  => admin_url( 'tools.php' ),
+				'pageSlug' => Constants::AUDIT_PAGE_SLUG,
+			);
+			if ( $this->print_inline_config( 'zwTTVGPTAudit', $audit_config ) ) {
 				wp_enqueue_script_module( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.js', array(), $version );
 			}
 			return;

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use ZW_TTVGPT_Core\AuditHelper;
 use ZW_TTVGPT_Core\AuditStatus;
+use ZW_TTVGPT_Core\Constants;
 
 /**
  * Renders the audit tools page and diff review UI.
@@ -280,7 +281,7 @@ class AuditPage {
 			<?php $this->render_status_links( $year, $month, $status_filter, $counts ); ?>
 
 			<form id="posts-filter" method="get">
-				<input type="hidden" name="page" value="zw-ttvgpt-audit">
+				<input type="hidden" name="page" value="<?php echo esc_attr( Constants::AUDIT_PAGE_SLUG ); ?>">
 				<?php
 				$this->render_tablenav(
 					$year,
@@ -328,7 +329,7 @@ class AuditPage {
 	 */
 	private function render_status_links( int $year, int $month, string $status_filter, array $counts ): void {
 		$total          = array_sum( $counts );
-		$base_url       = admin_url( 'tools.php?page=zw-ttvgpt-audit' );
+		$base_url       = admin_url( 'tools.php?page=' . Constants::AUDIT_PAGE_SLUG );
 		$current_params = array(
 			'year'  => $year,
 			'month' => $month,
@@ -489,7 +490,7 @@ class AuditPage {
 		}
 
 		$base_args = array(
-			'page'   => 'zw-ttvgpt-audit',
+			'page'   => Constants::AUDIT_PAGE_SLUG,
 			'year'   => $filters['year'],
 			'month'  => $filters['month'],
 			'status' => '' !== $filters['status_filter'] ? $filters['status_filter'] : false,


### PR DESCRIPTION
## Summary
- centralize the audit page slug in Constants and use it across audit admin URLs/config
- pass the audit page slug to the audit JS module instead of hardcoding it there
- remove redundant change/keyup word-counter listeners; input already covers text edits

This recovers the useful non-#161 changes from the local half-resolved stash without replaying stale PR #157 state.

## Testing
- vendor/bin/phpunit
- npm run lint
- vendor/bin/phpcs
- vendor/bin/phpstan analyse --memory-limit=1G