### PR TITLE
chore: inline single-use diff helpers

### DIFF
--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -68,21 +68,6 @@ class AuditHelper {
 	}
 
 	/**
-	 * Collapses whitespace runs in diff HTML; returns the input unchanged on PCRE failure.
-	 *
-	 * @param string $diff_html Diff HTML to normalize.
-	 */
-	private static function normalize_diff_whitespace( string $diff_html ): string {
-		$normalized = preg_replace( '/\s+/', ' ', $diff_html );
-
-		if ( null === $normalized ) {
-			self::log_pcre_failure( 'normalize_diff_whitespace' );
-		}
-
-		return null === $normalized ? $diff_html : $normalized;
-	}
-
-	/**
 	 * Plain-text fallback for both diff panes when highlighting cannot be trusted.
 	 *
 	 * @param string $old_clean      Original content after prefix stripping.
@@ -380,9 +365,21 @@ class AuditHelper {
 			return self::plain_diff_result( $old_clean, $modified_clean );
 		}
 
+		$before_normalized = preg_replace( '/\s+/', ' ', $before );
+		if ( null === $before_normalized ) {
+			self::log_pcre_failure( 'normalize_diff_whitespace' );
+			$before_normalized = $before;
+		}
+
+		$after_normalized = preg_replace( '/\s+/', ' ', $after );
+		if ( null === $after_normalized ) {
+			self::log_pcre_failure( 'normalize_diff_whitespace' );
+			$after_normalized = $after;
+		}
+
 		return array(
-			'before' => trim( self::normalize_diff_whitespace( $before ) ),
-			'after'  => trim( self::normalize_diff_whitespace( $after ) ),
+			'before' => trim( $before_normalized ),
+			'after'  => trim( $after_normalized ),
 		);
 	}
 

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -115,16 +115,6 @@ class AuditPage {
 	}
 
 	/**
-	 * Runs wp_kses(), including pre_kses callbacks that can return arbitrary
-	 * values. Callers must verify is_string() before echoing the result.
-	 *
-	 * @param string $diff_html Raw diff HTML.
-	 */
-	private static function kses_diff_html( string $diff_html ): mixed {
-		return wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
-	}
-
-	/**
 	 * Sanitizes diff HTML for the audit modal.
 	 *
 	 * The diff renderer emits unadorned <ins>/<del> tags. Letting wp_kses()
@@ -133,7 +123,9 @@ class AuditPage {
 	 * @param string $diff_html Raw diff HTML emitted by AuditHelper::generate_word_diff.
 	 */
 	public static function sanitize_diff_panel( string $diff_html ): string {
-		$kses_out = self::kses_diff_html( $diff_html );
+		$kses_out = wp_kses( $diff_html, self::DIFF_ALLOWED_TAGS );
+		// wp_kses() runs filters, so keep the runtime guard despite the string stub.
+		// @phpstan-ignore-next-line function.alreadyNarrowedType.
 		if ( ! is_string( $kses_out ) ) {
 			self::report_diff_sanitizer_failure( 'wp_kses_non_string' );
 			return wp_strip_all_tags( $diff_html );


### PR DESCRIPTION
## Summary
- Inline the single-use diff whitespace helper inside `generate_word_diff()` while preserving PCRE fallback behavior.
- Inline `wp_kses()` in `sanitize_diff_panel()` and keep the runtime non-string guard documented at the call site.
- Leave `remove_diff_tag()` as a shared helper because it still serves two tag-specific call sites.

Closes #163

## Testing
- `php -l includes/AuditHelper.php`
- `php -l includes/admin/AuditPage.php`
- `git diff --check`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --memory-limit=-1`