### PR TITLE
refactor: simplify cleanup across audit, api and helpers

### DIFF
--- a/assets/audit.css
+++ b/assets/audit.css
@@ -174,3 +174,22 @@
 .change-percentage.high-change {
     background: #dc3232;
 }
+
+.zw-diff-modal {
+    display: none;
+}
+
+.zw-diff-modal-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.zw-diff-panel {
+    max-height: 400px;
+    padding: 10px;
+    overflow-y: auto;
+    font-size: 13px;
+    line-height: 1.6;
+}

--- a/includes/ApiHandler.php
+++ b/includes/ApiHandler.php
@@ -121,7 +121,7 @@ class ApiHandler {
 	 *
 	 * @phpstan-return array<int, ChatMessage>
 	 */
-	public function build_messages( string $content, int $word_limit ): array {
+	private function build_messages( string $content, int $word_limit ): array {
 		return array(
 			array(
 				'role'    => 'system',

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -260,7 +260,7 @@ class AuditHelper {
 			return;
 		}
 
-		update_meta_cache( 'post', array_map( 'intval', $post_ids ) );
+		update_meta_cache( 'post', $post_ids );
 	}
 
 	/**
@@ -414,11 +414,18 @@ class AuditHelper {
 			return 100.0;
 		}
 
-		// Calculate similarity using simple word matching.
-		$max_words = max( $ai_word_count, $human_word_count );
+		// Multiset overlap: count each word only as many times as it appears in both sides,
+		// so repeated common words like "de" cannot inflate similarity past their human-side count.
+		$max_words    = max( $ai_word_count, $human_word_count );
+		$ai_counts    = array_count_values( $ai_words );
+		$human_counts = array_count_values( $human_words );
 
-		$common_words   = array_intersect( $ai_words, $human_words );
-		$matching_words = count( $common_words );
+		$matching_words = 0;
+		foreach ( $ai_counts as $word => $count ) {
+			if ( isset( $human_counts[ $word ] ) ) {
+				$matching_words += min( $count, $human_counts[ $word ] );
+			}
+		}
 
 		$similarity_ratio  = $matching_words / $max_words;
 		$change_percentage = ( 1 - $similarity_ratio ) * 100;

--- a/includes/Constants.php
+++ b/includes/Constants.php
@@ -250,6 +250,22 @@ class Constants {
 	public const float MIN_RESPONSE_RATIO = 0.2;
 
 	/**
+	 * Upper bound (inclusive) for the "low" change-percentage band in the audit UI.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	public const int CHANGE_BAND_LOW_MAX = 20;
+
+	/**
+	 * Upper bound (inclusive) for the "medium" change-percentage band in the audit UI.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	public const int CHANGE_BAND_MEDIUM_MAX = 50;
+
+	/**
 	 * Default system prompt for AI summary generation.
 	 *
 	 * Use %d as placeholder for word limit.

--- a/includes/Constants.php
+++ b/includes/Constants.php
@@ -252,6 +252,8 @@ class Constants {
 	/**
 	 * Upper bound (inclusive) for the "low" change-percentage band in the audit UI.
 	 *
+	 * Also acts as the exclusive lower threshold for the "medium" band.
+	 *
 	 * @since 1.0.0
 	 * @var int
 	 */
@@ -259,6 +261,8 @@ class Constants {
 
 	/**
 	 * Upper bound (inclusive) for the "medium" change-percentage band in the audit UI.
+	 *
+	 * Also acts as the exclusive lower threshold for the "high" band.
 	 *
 	 * @since 1.0.0
 	 * @var int

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -97,12 +97,37 @@ class Helper {
 	/**
 	 * Retrieves the version string for asset cache management.
 	 *
+	 * In debug mode the busting suffix is the latest filemtime across assets so
+	 * the browser revalidates when files actually change rather than on every
+	 * page load. Memoized per-request to avoid repeated file stats.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @return string Version string for asset enqueuing.
 	 */
 	public static function get_asset_version(): string {
-		return ZW_TTVGPT_VERSION . ( SettingsManager::is_debug_mode() ? '.' . time() : '' );
+		if ( ! SettingsManager::is_debug_mode() ) {
+			return ZW_TTVGPT_VERSION;
+		}
+
+		static $debug_version = null;
+		if ( null !== $debug_version ) {
+			return $debug_version;
+		}
+
+		$assets = glob( ZW_TTVGPT_DIR . 'assets/*' );
+		$latest = 0;
+		if ( is_array( $assets ) ) {
+			foreach ( $assets as $asset ) {
+				$mtime = filemtime( $asset );
+				if ( false !== $mtime && $mtime > $latest ) {
+					$latest = $mtime;
+				}
+			}
+		}
+
+		$debug_version = ZW_TTVGPT_VERSION . '.' . ( $latest > 0 ? $latest : time() );
+		return $debug_version;
 	}
 
 	/**

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -97,9 +97,11 @@ class Helper {
 	/**
 	 * Retrieves the version string for asset cache management.
 	 *
-	 * In debug mode the busting suffix is the latest filemtime across assets so
-	 * the browser revalidates when files actually change rather than on every
-	 * page load. Memoized per-request to avoid repeated file stats.
+	 * In debug mode the busting suffix is the latest filemtime across the
+	 * top-level assets directory, so the browser revalidates when files
+	 * actually change rather than on every page load. Falls back to a
+	 * per-request time() if no asset mtimes are readable. Memoized per-request
+	 * to avoid repeated file stats.
 	 *
 	 * @since 1.0.0
 	 *

--- a/includes/SettingsManager.php
+++ b/includes/SettingsManager.php
@@ -66,16 +66,20 @@ class SettingsManager {
 	public static function get_settings(): array {
 		$settings = wp_cache_get( self::CACHE_KEY, self::CACHE_GROUP );
 
-		if ( false === $settings ) {
-			$settings = get_option(
-				Constants::SETTINGS_OPTION_NAME,
-				Constants::get_default_settings()
-			);
-			$settings = is_array( $settings ) ? $settings : Constants::get_default_settings();
-			wp_cache_set( self::CACHE_KEY, $settings, self::CACHE_GROUP );
+		if ( is_array( $settings ) ) {
+			return $settings;
 		}
 
-		return is_array( $settings ) ? $settings : Constants::get_default_settings();
+		$settings = get_option(
+			Constants::SETTINGS_OPTION_NAME,
+			Constants::get_default_settings()
+		);
+		if ( ! is_array( $settings ) ) {
+			$settings = Constants::get_default_settings();
+		}
+
+		wp_cache_set( self::CACHE_KEY, $settings, self::CACHE_GROUP );
+		return $settings;
 	}
 
 	/**

--- a/includes/SummaryGenerator.php
+++ b/includes/SummaryGenerator.php
@@ -59,7 +59,7 @@ class SummaryGenerator {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in validate_ajax_request()
-		$content = isset( $_POST['content'] ) ? wp_unslash( $_POST['content'] ) : '';
+		$content = isset( $_POST['content'] ) ? (string) wp_unslash( $_POST['content'] ) : '';
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in validate_ajax_request()
 		$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
 

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -53,8 +53,8 @@ class AuditPage {
 		return array(
 			'year'          => $year,
 			'month'         => $month,
-			'status_filter' => isset( $_GET['status'] ) ? sanitize_text_field( $_GET['status'] ) : '',
-			'change_filter' => isset( $_GET['change'] ) ? sanitize_text_field( $_GET['change'] ) : '',
+			'status_filter' => isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '',
+			'change_filter' => isset( $_GET['change'] ) ? sanitize_text_field( wp_unslash( $_GET['change'] ) ) : '',
 			'paged'         => isset( $_GET['paged'] ) ? max( 1, absint( $_GET['paged'] ) ) : 1,
 		);
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -184,13 +184,14 @@ class AuditPage {
 
 			$status_match = empty( $status_filter ) || $status->value === $status_filter;
 
+			$pct          = $analysis['change_percentage'];
 			$change_match = match ( true ) {
 				empty( $change_filter )                       => true,
 				AuditStatus::AiWrittenEdited !== $status      => false,
 				default                                       => match ( $change_filter ) {
-					'low'    => $analysis['change_percentage'] <= 20,
-					'medium' => $analysis['change_percentage'] > 20 && $analysis['change_percentage'] <= 50,
-					'high'   => $analysis['change_percentage'] > 50,
+					'low'    => $pct <= Constants::CHANGE_BAND_LOW_MAX,
+					'medium' => $pct > Constants::CHANGE_BAND_LOW_MAX && $pct <= Constants::CHANGE_BAND_MEDIUM_MAX,
+					'high'   => $pct > Constants::CHANGE_BAND_MEDIUM_MAX,
 					default  => true,
 				},
 			};
@@ -352,28 +353,43 @@ class AuditPage {
 					<label for="filter-by-status" class="screen-reader-text"><?php esc_html_e( 'Op type filteren', 'zw-ttvgpt' ); ?></label>
 					<select name="status" id="filter-by-status">
 						<option value=""><?php esc_html_e( 'Alle types', 'zw-ttvgpt' ); ?></option>
-						<option value="fully_human_written" <?php selected( $status_filter, 'fully_human_written' ); ?>>
-							<?php esc_html_e( 'Handgeschreven', 'zw-ttvgpt' ); ?>
-						</option>
-						<option value="ai_written_not_edited" <?php selected( $status_filter, 'ai_written_not_edited' ); ?>>
-							<?php esc_html_e( 'AI-gegenereerd', 'zw-ttvgpt' ); ?>
-						</option>
-						<option value="ai_written_edited" <?php selected( $status_filter, 'ai_written_edited' ); ?>>
-							<?php esc_html_e( 'AI-bewerkt', 'zw-ttvgpt' ); ?>
-						</option>
+						<?php foreach ( AuditStatus::cases() as $status_case ) : ?>
+							<option value="<?php echo esc_attr( $status_case->value ); ?>" <?php selected( $status_filter, $status_case->value ); ?>>
+								<?php echo esc_html( $status_case->get_label() ); ?>
+							</option>
+						<?php endforeach; ?>
 					</select>
 
 					<label for="filter-by-change" class="screen-reader-text"><?php esc_html_e( 'Op wijzigingspercentage filteren', 'zw-ttvgpt' ); ?></label>
 					<select name="change" id="filter-by-change">
 						<option value=""><?php esc_html_e( 'Alle wijzigingen', 'zw-ttvgpt' ); ?></option>
 						<option value="low" <?php selected( $change_filter, 'low' ); ?>>
-							<?php esc_html_e( 'Laag (≤20%)', 'zw-ttvgpt' ); ?>
+							<?php
+							printf(
+								/* translators: %d: upper-bound percentage for the low change band */
+								esc_html__( 'Laag (≤%d%%)', 'zw-ttvgpt' ),
+								(int) Constants::CHANGE_BAND_LOW_MAX
+							);
+							?>
 						</option>
 						<option value="medium" <?php selected( $change_filter, 'medium' ); ?>>
-							<?php esc_html_e( 'Gemiddeld (21-50%)', 'zw-ttvgpt' ); ?>
+							<?php
+							printf(
+								/* translators: 1: low-band upper bound + 1, 2: medium-band upper bound */
+								esc_html__( 'Gemiddeld (%1$d-%2$d%%)', 'zw-ttvgpt' ),
+								(int) Constants::CHANGE_BAND_LOW_MAX + 1,
+								(int) Constants::CHANGE_BAND_MEDIUM_MAX
+							);
+							?>
 						</option>
 						<option value="high" <?php selected( $change_filter, 'high' ); ?>>
-							<?php esc_html_e( 'Hoog (>50%)', 'zw-ttvgpt' ); ?>
+							<?php
+							printf(
+								/* translators: %d: upper-bound percentage above which change is "high" */
+								esc_html__( 'Hoog (>%d%%)', 'zw-ttvgpt' ),
+								(int) Constants::CHANGE_BAND_MEDIUM_MAX
+							);
+							?>
 						</option>
 					</select>
 
@@ -464,6 +480,20 @@ class AuditPage {
 	 * @phpstan-param array<int, array<string, mixed>> $categorized_posts
 	 */
 	private function render_audit_table( array $categorized_posts ): void {
+		// Prime the user cache so per-row get_userdata() calls don't each hit the DB.
+		$user_ids = array();
+		foreach ( $categorized_posts as $item ) {
+			$post       = $item['post'];
+			$user_ids[] = (int) $post->post_author;
+			$edit_last  = get_post_meta( $post->ID, '_edit_last', true );
+			if ( is_numeric( $edit_last ) ) {
+				$user_ids[] = (int) $edit_last;
+			}
+		}
+		$user_ids = array_values( array_unique( array_filter( $user_ids ) ) );
+		if ( ! empty( $user_ids ) ) {
+			cache_users( $user_ids );
+		}
 		?>
 		<h2 class="screen-reader-text"><?php esc_html_e( 'Auditlog', 'zw-ttvgpt' ); ?></h2>
 		<table class="wp-list-table widefat fixed striped table-view-list posts zw-audit-table">
@@ -584,7 +614,9 @@ class AuditPage {
 								<?php if ( AuditStatus::AiWrittenEdited === $status && isset( $item['change_percentage'] ) ) : ?>
 									<?php
 									$pct       = $item['change_percentage'];
-									$pct_class = $pct > 50 ? 'high-change' : ( $pct > 20 ? 'medium-change' : 'low-change' );
+									$pct_class = $pct > Constants::CHANGE_BAND_MEDIUM_MAX
+										? 'high-change'
+										: ( $pct > Constants::CHANGE_BAND_LOW_MAX ? 'medium-change' : 'low-change' );
 									?>
 									<span class="change-percentage <?php echo esc_attr( $pct_class ); ?>">
 										<?php echo esc_html( $pct . '%' ); ?>
@@ -624,21 +656,21 @@ class AuditPage {
 				$post = $item['post'];
 				$diff = AuditHelper::generate_word_diff( $item['ai_content'], $item['human_content'] );
 				?>
-				<div id="zw-diff-modal-<?php echo esc_attr( $post->ID ); ?>" style="display: none;">
+				<div id="zw-diff-modal-<?php echo esc_attr( (string) $post->ID ); ?>" class="zw-diff-modal">
 					<div class="wrap">
 						<?php
 						/* translators: %s is the post title. */
 						$modal_title = sprintf( __( 'Verschillen voor: %s', 'zw-ttvgpt' ), get_the_title( $post->ID ) );
 						?>
 						<h2><?php echo esc_html( $modal_title ); ?></h2>
-						
-						<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 20px;">
+
+						<div class="zw-diff-modal-grid">
 							<div class="postbox">
 								<div class="postbox-header">
 									<h3 class="hndle"><?php esc_html_e( 'AI-versie', 'zw-ttvgpt' ); ?></h3>
 								</div>
 								<div class="inside">
-									<div class="zw-diff-panel" style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
+									<div class="zw-diff-panel">
 										<?php
 											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is sanitized by sanitize_diff_panel().
 											echo self::sanitize_diff_panel( $diff['before'] );
@@ -646,13 +678,13 @@ class AuditPage {
 									</div>
 								</div>
 							</div>
-							
+
 							<div class="postbox">
 								<div class="postbox-header">
 									<h3 class="hndle"><?php esc_html_e( 'Bewerkte versie', 'zw-ttvgpt' ); ?></h3>
 								</div>
 								<div class="inside">
-									<div class="zw-diff-panel" style="max-height: 400px; overflow-y: auto; padding: 10px; font-size: 13px; line-height: 1.6;">
+									<div class="zw-diff-panel">
 										<?php
 											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is sanitized by sanitize_diff_panel().
 											echo self::sanitize_diff_panel( $diff['after'] );

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -375,7 +375,7 @@ class AuditPage {
 						<option value="medium" <?php selected( $change_filter, 'medium' ); ?>>
 							<?php
 							printf(
-								/* translators: 1: low-band upper bound + 1, 2: medium-band upper bound */
+								/* translators: 1: lower bound, 2: upper bound for the medium change band */
 								esc_html__( 'Gemiddeld (%1$d-%2$d%%)', 'zw-ttvgpt' ),
 								(int) Constants::CHANGE_BAND_LOW_MAX + 1,
 								(int) Constants::CHANGE_BAND_MEDIUM_MAX
@@ -472,6 +472,9 @@ class AuditPage {
 
 	/**
 	 * Renders WordPress-style table with audit data.
+	 *
+	 * Primes author/editor user caches before rendering rows to avoid N+1
+	 * get_userdata() lookups.
 	 *
 	 * @since 1.0.0
 	 *


### PR DESCRIPTION
## Summary

Cleanup pass driven by a multi-agent code review of the production code (`includes/`, `assets/`). Fixes one correctness bug, two hardening gaps, and a mix of dead code, duplication, and a real perf cliff.

### Correctness

- `AuditHelper::calculate_change_percentage` previously used `array_intersect`, which deduplicates and ignores per-word frequency. Repeated common words (e.g. \"de\", \"het\") inflated similarity past the human-side count. Replaced with a multiset comparison via `array_count_values`. Existing test cases still pass; the math is unchanged for non-repeated tokens.

### Hardening

- `$_GET['status']` and `$_GET['change']` now go through `wp_unslash` before `sanitize_text_field`, matching the neighbouring `m` reader.
- `$_POST['content']` is cast to `(string)` before flowing into `preg_replace` in `prepare_content`.

### Performance

- `Helper::get_asset_version` no longer appends `time()` in debug mode. It now uses the max `filemtime()` across `assets/` and memoizes per request, so browsers revalidate only when files actually change.
- `AuditPage::render_audit_table` primes `cache_users()` for all distinct author and editor IDs before the row loop, cutting up to ~100 per-page user lookups.

### Cleanup

- Status filter dropdown loops `AuditStatus::cases()` instead of three hardcoded `<option>` literals.
- The 20 percent and 50 percent change-band thresholds live as `Constants::CHANGE_BAND_LOW_MAX` / `CHANGE_BAND_MEDIUM_MAX`, used in the filter logic, row CSS class and option labels.
- Diff-modal `style=\"...\"` attributes moved into `audit.css` as `.zw-diff-modal`, `.zw-diff-modal-grid`, `.zw-diff-panel`.
- `SettingsManager::get_settings` drops a dead post-cache `is_array` ternary by tightening control flow.
- `AuditHelper::prime_meta_cache` drops a redundant `array_map('intval', ...)` over already-int IDs.
- `ApiHandler::build_messages` visibility tightened from `public` to `private` (no external callers).

## Out of scope

Five follow-ups filed as separate issues for findings that need more discussion or larger changes: #167 (verify `DEFAULT_MODEL='gpt-5.5'`), #168 (lazy-load diff modals via AJAX), #169 (tighten `prepare_content` visibility), #170 (CLAUDE.md drift), #171 (share word-count tokenizer between PHP and JS).

## Test plan

- [x] `vendor/bin/phpcs` clean
- [x] `vendor/bin/phpstan analyse` (memory bumped to 1G) clean
- [x] `npm run lint` clean
- [x] `vendor/bin/phpunit` (117 tests, 235 assertions) passes
- [ ] Manual smoke: audit page renders, status filter works, change-band filter still gates rows at the same percentages, diff modal opens and shows before/after styling matches.
- [ ] Manual smoke: generate a summary on a post end-to-end.