### PR TITLE
fix: share word tokenizer across editor and audit

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -23,6 +23,12 @@ const MESSAGE_TIMING = {
     typeStartDelay: 100,
 };
 
+const config = window.zwTTVGPT ?? {};
+const WORD_TOKEN_REGEX =
+    typeof config.wordTokenPattern === 'string'
+        ? new RegExp(config.wordTokenPattern, 'gu')
+        : null;
+
 let cachedAcfField = null;
 let cachedGptField = null;
 let cachedWordCounter = null;
@@ -69,7 +75,6 @@ function init() {
  * DOM ready handler - cache elements and inject button.
  */
 function onReady() {
-    const config = window.zwTTVGPT;
     if (!config?.acfFields) {
         return;
     }
@@ -87,12 +92,12 @@ function onReady() {
  * @return {number} Word count.
  */
 function countWords(text) {
-    if (!text || typeof text !== 'string') {
+    if (!text || typeof text !== 'string' || !WORD_TOKEN_REGEX) {
         return 0;
     }
     let count = 0;
-    const regex = /[\p{L}]+([-'][\p{L}]+)*/gu;
-    while (regex.exec(text)) {
+    WORD_TOKEN_REGEX.lastIndex = 0;
+    while (WORD_TOKEN_REGEX.exec(text)) {
         count++;
     }
     return count;

--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -401,14 +401,15 @@ class AuditHelper {
 			return 100.0;
 		}
 
-		$ai_words_result    = preg_split( '/\s+/', trim( $ai_content ) );
-		$human_words_result = preg_split( '/\s+/', trim( $human_content ) );
-
-		$ai_words    = false !== $ai_words_result ? $ai_words_result : array();
-		$human_words = false !== $human_words_result ? $human_words_result : array();
+		$ai_words    = Helper::tokenize_words( $ai_content );
+		$human_words = Helper::tokenize_words( $human_content );
 
 		$ai_word_count    = count( $ai_words );
 		$human_word_count = count( $human_words );
+
+		if ( 0 === $ai_word_count && 0 === $human_word_count ) {
+			return 0.0;
+		}
 
 		if ( 0 === $ai_word_count ) {
 			return 100.0;

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -27,7 +27,7 @@ class Helper {
 	 *
 	 * @since 1.0.0
 	 */
-	public const string WORD_TOKEN_PATTERN = '[\p{L}]+([-\'][\p{L}]+)*';
+	public const string WORD_TOKEN_PATTERN = '[\p{L}]+(?:[-\'][\p{L}]+)*';
 
 	/**
 	 * Removes plugin-owned transient rows from wp_options.

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -23,6 +23,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Helper {
 
 	/**
+	 * Regex fragment used to tokenize words consistently across PHP and JS.
+	 *
+	 * @since 1.0.0
+	 */
+	public const string WORD_TOKEN_PATTERN = '[\p{L}]+([-\'][\p{L}]+)*';
+
+	/**
 	 * Removes plugin-owned transient rows from wp_options.
 	 *
 	 * Only called on deactivation and uninstall, so any persistent-object-cache
@@ -148,7 +155,7 @@ class Helper {
 	}
 
 	/**
-	 * Counts words in a text using a Unicode-aware tokenizer.
+	 * Tokenizes words in a text using a Unicode-aware pattern.
 	 *
 	 * A word is one or more Unicode letters, optionally followed by groups of a
 	 * hyphen or apostrophe and more letters (e.g. "zelf-rijdend", "auto's"). This
@@ -158,10 +165,29 @@ class Helper {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param string $text Text to tokenize.
+	 * @return array Word tokens.
+	 *
+	 * @phpstan-return list<string>
+	 */
+	public static function tokenize_words( string $text ): array {
+		$matched = preg_match_all( '/' . self::WORD_TOKEN_PATTERN . '/u', $text, $matches );
+		if ( false === $matched ) {
+			return array();
+		}
+
+		return $matches[0];
+	}
+
+	/**
+	 * Counts words in a text using a Unicode-aware tokenizer.
+	 *
+	 * @since 1.0.0
+	 *
 	 * @param string $text Text to count words in.
 	 * @return int Number of words.
 	 */
 	public static function count_words( string $text ): int {
-		return (int) preg_match_all( '/[\p{L}]+([-\'][\p{L}]+)*/u', $text );
+		return count( self::tokenize_words( $text ) );
 	}
 }

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -128,18 +128,19 @@ class AdminMenu {
 
 		// Inline script data before module loads (wp_enqueue_script_module doesn't support wp_localize_script).
 		$inline_data = array(
-			'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
-			'nonce'          => wp_create_nonce( 'zw_ttvgpt_nonce' ),
-			'acfFields'      => Helper::get_acf_field_ids(),
-			'debugMode'      => SettingsManager::is_debug_mode(),
-			'wordLimit'      => SettingsManager::get_word_limit(),
-			'animationDelay' => array(
+			'ajaxUrl'          => admin_url( 'admin-ajax.php' ),
+			'nonce'            => wp_create_nonce( 'zw_ttvgpt_nonce' ),
+			'acfFields'        => Helper::get_acf_field_ids(),
+			'debugMode'        => SettingsManager::is_debug_mode(),
+			'wordLimit'        => SettingsManager::get_word_limit(),
+			'wordTokenPattern' => Helper::WORD_TOKEN_PATTERN,
+			'animationDelay'   => array(
 				'min'   => 20,
 				'max'   => 50,
 				'space' => 30,
 			),
-			'timeouts'       => array( 'successMessage' => 3000 ),
-			'strings'        => array(
+			'timeouts'         => array( 'successMessage' => 3000 ),
+			'strings'          => array(
 				'generating'      => __( 'Genereren...', 'zw-ttvgpt' ),
 				'error'           => __( 'Fout opgetreden', 'zw-ttvgpt' ),
 				'success'         => __( 'Klaar!', 'zw-ttvgpt' ),

--- a/tests/AdminAssetWordTokenPatternTest.php
+++ b/tests/AdminAssetWordTokenPatternTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class AdminAssetWordTokenPatternTest extends TestCase {
+
+	public function test_admin_script_builds_word_counter_regex_from_inline_config(): void {
+		$script = file_get_contents( dirname( __DIR__ ) . '/assets/admin.js' );
+		self::assertIsString( $script );
+
+		self::assertStringContainsString( "new RegExp(config.wordTokenPattern, 'gu')", $script );
+		self::assertStringNotContainsString( '/[\p{L}]+', $script );
+	}
+}

--- a/tests/AdminMenuInlineConfigTest.php
+++ b/tests/AdminMenuInlineConfigTest.php
@@ -13,8 +13,51 @@ namespace {
 		define( 'ZW_TTVGPT_URL', 'https://example.test/wp-content/plugins/zw-ttvgpt/' );
 	}
 
+	$GLOBALS['zw_test_current_screen'] = false;
+	$GLOBALS['zw_test_inline_scripts'] = array();
+	$GLOBALS['zw_test_styles']         = array();
+
 	if ( ! function_exists( 'add_action' ) ) {
 		require_once ABSPATH . 'wp-includes/plugin.php';
+	}
+
+	if ( ! function_exists( 'get_current_screen' ) ) {
+		function get_current_screen(): object|false {
+			return $GLOBALS['zw_test_current_screen'];
+		}
+	}
+
+	if ( ! function_exists( 'wp_create_nonce' ) ) {
+		function wp_create_nonce( string $action = '-1' ): string {
+			return 'test-nonce-' . $action;
+		}
+	}
+
+	if ( ! function_exists( 'wp_enqueue_style' ) ) {
+		function wp_enqueue_style(
+			string $handle,
+			string $src = '',
+			array $deps = array(),
+			mixed $ver = false,
+			string $media = 'all'
+		): void {
+			$GLOBALS['zw_test_styles'][] = array(
+				'handle' => $handle,
+				'src'    => $src,
+				'deps'   => $deps,
+				'ver'    => $ver,
+				'media'  => $media,
+			);
+		}
+	}
+
+	if ( ! function_exists( 'wp_print_inline_script_tag' ) ) {
+		function wp_print_inline_script_tag( string $script, array $attributes = array() ): void {
+			$GLOBALS['zw_test_inline_scripts'][] = array(
+				'script'     => $script,
+				'attributes' => $attributes,
+			);
+		}
 	}
 }
 
@@ -26,6 +69,7 @@ namespace ZW_TTVGPT_Core\Tests {
 	use ZW_TTVGPT_Core\Admin\AdminMenu;
 	use ZW_TTVGPT_Core\Admin\SettingsPage;
 	use ZW_TTVGPT_Core\Constants;
+	use ZW_TTVGPT_Core\Helper;
 
 	final class BadInlineConfigSettingsPage extends SettingsPage {
 		public function __construct() {}
@@ -51,10 +95,15 @@ namespace ZW_TTVGPT_Core\Tests {
 
 		protected function setUp(): void {
 			$GLOBALS['zw_test_script_modules'] = array();
+			$GLOBALS['zw_test_inline_scripts'] = array();
+			$GLOBALS['zw_test_styles']         = array();
+			$GLOBALS['zw_test_current_screen'] = false;
+			remove_all_actions( 'admin_print_footer_scripts' );
 			remove_all_actions( 'zw_ttvgpt_diff_sanitizer_failed' );
 		}
 
 		protected function tearDown(): void {
+			remove_all_actions( 'admin_print_footer_scripts' );
 			remove_all_actions( 'zw_ttvgpt_diff_sanitizer_failed' );
 		}
 
@@ -78,6 +127,22 @@ namespace ZW_TTVGPT_Core\Tests {
 
 			self::assertSame( 'zw-ttvgpt-settings', $GLOBALS['zw_test_script_modules'][0]['id'] );
 			self::assertSame( array(), $logger->errors );
+		}
+
+		public function test_editor_config_exposes_word_token_pattern(): void {
+			$logger = new RecordingLogger();
+			$menu   = self::newAdminMenu( $logger, new GoodInlineConfigSettingsPage() );
+
+			$GLOBALS['zw_test_current_screen'] = (object) array( 'post_type' => Constants::SUPPORTED_POST_TYPE );
+
+			$menu->enqueue_admin_assets( 'post.php' );
+			do_action( 'admin_print_footer_scripts' );
+
+			self::assertSame( 'zw-ttvgpt-admin', $GLOBALS['zw_test_script_modules'][0]['id'] );
+			self::assertCount( 1, $GLOBALS['zw_test_inline_scripts'] );
+
+			$config = self::decodeInlineConfig( $GLOBALS['zw_test_inline_scripts'][0]['script'] );
+			self::assertSame( Helper::WORD_TOKEN_PATTERN, $config['wordTokenPattern'] );
 		}
 
 		public function test_diff_sanitizer_failure_hook_is_logged(): void {
@@ -108,6 +173,18 @@ namespace ZW_TTVGPT_Core\Tests {
 			$settings_page_property->setValue( $menu, $settings_page );
 
 			return $menu;
+		}
+
+		/**
+		 * @return array<string, mixed>
+		 */
+		private static function decodeInlineConfig( string $script ): array {
+			self::assertSame( 1, preg_match( '/^window\.zwTTVGPT = (.*);$/', $script, $matches ) );
+
+			$decoded = json_decode( $matches[1], true );
+			self::assertIsArray( $decoded );
+
+			return $decoded;
 		}
 	}
 }

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -79,6 +79,16 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 		);
 	}
 
+	public function test_calculate_change_percentage_uses_unicode_word_tokens(): void {
+		self::assertSame(
+			20.0,
+			AuditHelper::calculate_change_percentage(
+				'CURAÇAO - Het café opent vandaag',
+				'CURAÇAO - Het café opent morgen'
+			)
+		);
+	}
+
 	public function test_generate_word_diff_falls_back_to_plain_text_when_diff_stripping_regex_fails(): void {
 		$log_file           = tempnam( sys_get_temp_dir(), 'zw-ttvgpt-pcre-' );
 		$previous_error_log = false;

--- a/tests/AuditHelperRegionPrefixTest.php
+++ b/tests/AuditHelperRegionPrefixTest.php
@@ -67,6 +67,10 @@ final class AuditHelperRegionPrefixTest extends TestCase {
 		self::assertSame( 100.0, AuditHelper::calculate_change_percentage( 'human content', '' ) );
 	}
 
+	public function test_calculate_change_percentage_no_word_tokens_returns_zero(): void {
+		self::assertSame( 0.0, AuditHelper::calculate_change_percentage( '3,5', '---' ) );
+	}
+
 	public function test_calculate_change_percentage_identical_returns_zero(): void {
 		self::assertSame( 0.0, AuditHelper::calculate_change_percentage( 'same words here', 'same words here' ) );
 	}

--- a/tests/HelperWordCountTest.php
+++ b/tests/HelperWordCountTest.php
@@ -24,6 +24,18 @@ final class HelperWordCountTest extends TestCase {
 		self::assertSame( $expected, Helper::tokenize_words( $input ) );
 	}
 
+	public function test_tokenize_words_returns_empty_array_when_pcre_fails(): void {
+		$previous_limit = ini_set( 'pcre.backtrack_limit', '1' );
+
+		try {
+			self::assertSame( array(), Helper::tokenize_words( 'zelf-rijdend cafe' ) );
+		} finally {
+			if ( false !== $previous_limit ) {
+				ini_set( 'pcre.backtrack_limit', $previous_limit );
+			}
+		}
+	}
+
 	/**
 	 * @return array<string, array{string, int}>
 	 */
@@ -57,6 +69,7 @@ final class HelperWordCountTest extends TestCase {
 	public static function wordTokenProvider(): array {
 		return array(
 			'empty string'                     => array( '', array() ),
+			'whitespace only'                  => array( "   \t\n", array() ),
 			'diacritics and compounds'        => array( "Curaçao café auto's zelf-rijdend", array( 'Curaçao', 'café', "auto's", 'zelf-rijdend' ) ),
 			'punctuation is not a token'      => array( 'CURAÇAO - Het café opent.', array( 'CURAÇAO', 'Het', 'café', 'opent' ) ),
 			'leading apostrophe starts token' => array( "'s avonds", array( 's', 'avonds' ) ),

--- a/tests/HelperWordCountTest.php
+++ b/tests/HelperWordCountTest.php
@@ -17,6 +17,14 @@ final class HelperWordCountTest extends TestCase {
 	}
 
 	/**
+	 * @param list<string> $expected
+	 */
+	#[DataProvider('wordTokenProvider')]
+	public function test_tokenize_words( string $input, array $expected ): void {
+		self::assertSame( $expected, Helper::tokenize_words( $input ) );
+	}
+
+	/**
 	 * @return array<string, array{string, int}>
 	 */
 	public static function wordCountProvider(): array {
@@ -40,6 +48,19 @@ final class HelperWordCountTest extends TestCase {
 			// Regression: old str_word_count overcounted these cases and triggered retries.
 			'regression: 15x diacritic sentence'    => array( str_repeat( 'Het café serveert crème brûlée. ', 15 ), 75 ),
 			'regression: 18x em-dash sentence'      => array( str_repeat( 'Bergen op Zoom – Breda blijft bereikbaar. ', 18 ), 108 ),
+		);
+	}
+
+	/**
+	 * @return array<string, array{string, list<string>}>
+	 */
+	public static function wordTokenProvider(): array {
+		return array(
+			'empty string'                     => array( '', array() ),
+			'diacritics and compounds'        => array( "Curaçao café auto's zelf-rijdend", array( 'Curaçao', 'café', "auto's", 'zelf-rijdend' ) ),
+			'punctuation is not a token'      => array( 'CURAÇAO - Het café opent.', array( 'CURAÇAO', 'Het', 'café', 'opent' ) ),
+			'leading apostrophe starts token' => array( "'s avonds", array( 's', 'avonds' ) ),
+			'numbers are skipped'             => array( '3,5 miljoen euro', array( 'miljoen', 'euro' ) ),
 		);
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a shared PHP word-token pattern and tokenizer for summary validation.
- Passes the tokenizer pattern to the admin editor JS and reuses it for the live word counter.
- Uses the same tokenizer for audit change percentages, with regressions for diacritics and punctuation.

## Verification
- vendor/bin/phpunit
- npm run lint
- vendor/bin/phpcs
- vendor/bin/phpstan analyse --memory-limit=1G

Closes #171
Closes #162