### PR TITLE
refactor: move HTML-to-text helper out of ApiHandler

### DIFF
--- a/includes/ApiHandler.php
+++ b/includes/ApiHandler.php
@@ -82,35 +82,6 @@ class ApiHandler {
 	}
 
 	/**
-	 * Extracts clean text from HTML content.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $content Raw content to clean.
-	 * @return string Cleaned content ready for API.
-	 */
-	public function prepare_content( string $content ): string {
-		// Remove script-like elements including their content; wp_strip_all_tags() only removes tags.
-		$content = preg_replace( '/<script\b[^>]*>.*?<\/script>/is', '', $content ) ?? $content;
-		$content = preg_replace( '/<style\b[^>]*>.*?<\/style>/is', '', $content ) ?? $content;
-		$content = preg_replace( '/<noscript\b[^>]*>.*?<\/noscript>/is', '', $content ) ?? $content;
-
-		// Convert block elements to newlines for proper paragraph spacing.
-		$content = preg_replace( '/<\/(p|div|h[1-6]|li|tr|blockquote)>/i', "\n", $content ) ?? $content;
-		$content = preg_replace( '/<br\s*\/?>/i', "\n", $content ) ?? $content;
-
-		$text = wp_strip_all_tags( $content );
-
-		$text = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-
-		// Normalize whitespace.
-		$text = preg_replace( '/[ \t]+/', ' ', $text ) ?? $text;
-		$text = preg_replace( '/\n{3,}/', "\n\n", $text ) ?? $text;
-
-		return trim( $text );
-	}
-
-	/**
 	 * Creates the messages structure for the Chat Completions API.
 	 *
 	 * @since 1.0.0

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Helper class.
  *
- * Provides utility functions for transients, ACF fields, and validation.
+ * Provides utility functions for transients, ACF fields, validation, and text handling.
  *
  * @package ZW_TTVGPT
  * @since   1.0.0
@@ -152,6 +152,35 @@ class Helper {
 
 		// Accept any gpt-5* model for Responses API (forward compatibility).
 		return str_starts_with( $model_lower, 'gpt-5' );
+	}
+
+	/**
+	 * Converts editor HTML content to plain text.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $content Raw HTML content to clean.
+	 * @return string Plain text content.
+	 */
+	public static function html_to_text( string $content ): string {
+		// Remove script-like elements including their content; wp_strip_all_tags() only removes tags.
+		$content = preg_replace( '/<script\b[^>]*>.*?<\/script>/is', '', $content ) ?? $content;
+		$content = preg_replace( '/<style\b[^>]*>.*?<\/style>/is', '', $content ) ?? $content;
+		$content = preg_replace( '/<noscript\b[^>]*>.*?<\/noscript>/is', '', $content ) ?? $content;
+
+		// Convert block elements to newlines for proper paragraph spacing.
+		$content = preg_replace( '/<\/(p|div|h[1-6]|li|tr|blockquote)>/i', "\n", $content ) ?? $content;
+		$content = preg_replace( '/<br\s*\/?>/i', "\n", $content ) ?? $content;
+
+		$text = wp_strip_all_tags( $content );
+
+		$text = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+		// Normalize whitespace.
+		$text = preg_replace( '/[ \t]+/', ' ', $text ) ?? $text;
+		$text = preg_replace( '/\n{3,}/', "\n\n", $text ) ?? $text;
+
+		return trim( $text );
 	}
 
 	/**

--- a/includes/SummaryGenerator.php
+++ b/includes/SummaryGenerator.php
@@ -71,7 +71,7 @@ class SummaryGenerator {
 			);
 		}
 
-		$clean_content = $this->api_handler->prepare_content( $content );
+		$clean_content = Helper::html_to_text( $content );
 		$word_count    = Helper::count_words( $clean_content );
 
 		if ( $word_count < Constants::MIN_WORD_COUNT ) {

--- a/tests/HelperHtmlToTextTest.php
+++ b/tests/HelperHtmlToTextTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZW_TTVGPT_Core\Helper;
+
+require_once __DIR__ . '/wp-load-helper.php';
+
+#[CoversClass(Helper::class)]
+final class HelperHtmlToTextTest extends TestCase {
+
+	#[DataProvider('htmlProvider')]
+	public function test_html_to_text( string $input, string $expected ): void {
+		self::assertSame( $expected, Helper::html_to_text( $input ) );
+	}
+
+	/**
+	 * @return array<string, array{string, string}>
+	 */
+	public static function htmlProvider(): array {
+		return array(
+			'plain text is trimmed'               => array( '  artikel tekst  ', 'artikel tekst' ),
+			'block elements become newlines'      => array( '<p>Eerste</p><div>Tweede<br>regel</div>', "Eerste\nTweede\nregel" ),
+			'script-like content is removed'      => array( '<p>Start</p><script>alert("x")</script><style>.x{}</style><noscript>fallback</noscript><p>Eind</p>', "Start\nEind" ),
+			'entities are decoded'               => array( '<p>Auto&apos;s &amp; fietsen</p>', "Auto's & fietsen" ),
+			'excess whitespace is normalized'     => array( "<p>Veel   spaties</p>\n\n\n\n<p>Nieuwe\tregel</p>", "Veel spaties\n\nNieuwe regel" ),
+			'unsafe inline markup becomes text'   => array( '<p>Tekst <strong>met nadruk</strong></p>', 'Tekst met nadruk' ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Move `ApiHandler::prepare_content()` to `Helper::html_to_text()` as a static method — the cleanup is generic HTML→plaintext, not API-specific
- Update `SummaryGenerator.php:74` to call the helper directly; validation order (word-count before rate-limit and API call) stays intact
- Add unit tests covering script/style/noscript stripping, block→newline conversion, entity decoding, and whitespace normalization (this cleanup had no test coverage before)

Closes #169.

## Test plan
- [ ] `vendor/bin/phpcs`
- [ ] `vendor/bin/phpstan analyse`
- [ ] `vendor/bin/phpunit tests/HelperHtmlToTextTest.php`
- [ ] Manual: generate a summary in the editor and confirm HTML cleanup still produces the same plaintext input