### PR TITLE
chore: lowercase phpunit testsuite name

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
          failOnWarning="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>
-        <testsuite name="Unit">
+        <testsuite name="unit">
             <directory>tests</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
## Summary
- Rename the PHPUnit suite in `phpunit.xml.dist` from `Unit` to `unit` so `vendor/bin/phpunit --testsuite unit` works without case gymnastics.
- Lowercase matches the convention used in most PHP projects.

CI is unaffected — `.github/workflows/test.yml` runs `vendor/bin/phpunit` without a `--testsuite` filter.

Closes #158.

## Test plan
- [x] `vendor/bin/phpunit --testsuite unit` runs the full suite (134 tests, 258 assertions, exit 0)
- [x] `vendor/bin/phpunit` (no filter) still passes