### PR TITLE
fix: lazy-load audit diffs

### DIFF
--- a/assets/audit.css
+++ b/assets/audit.css
@@ -186,6 +186,19 @@
     margin-top: 20px;
 }
 
+.zw-diff-modal-status {
+    padding: 12px;
+    margin-top: 20px;
+    background: #f6f7f7;
+    border-left: 4px solid #72aee6;
+}
+
+.zw-diff-modal-grid[hidden],
+.zw-diff-modal-status[hidden],
+.zw-diff-modal-error[hidden] {
+    display: none;
+}
+
 .zw-diff-panel {
     max-height: 400px;
     padding: 10px;

--- a/assets/audit.js
+++ b/assets/audit.js
@@ -1,11 +1,16 @@
-/** Submit audit filters via navigation to preserve WP tablenav behavior. */
+/** Submit audit filters via navigation and lazy-load diff modals. */
 
 const config = window.zwTTVGPTAudit;
 if (!config) {
     console.warn(
-        'zw-ttvgpt: audit config missing, filter handlers not attached',
+        'zw-ttvgpt: audit config missing, audit handlers not attached',
     );
 } else {
+    attachFilterHandlers();
+    attachDiffHandlers();
+}
+
+function attachFilterHandlers() {
     const date = document.getElementById('filter-by-date');
     const status = document.getElementById('filter-by-status');
     const change = document.getElementById('filter-by-change');
@@ -40,4 +45,128 @@ if (!config) {
         e.preventDefault();
         applyFilters();
     });
+}
+
+function attachDiffHandlers() {
+    const links = document.querySelectorAll('.zw-audit-diff-link');
+    const modalTitle = document.getElementById('zw-diff-modal-title');
+    const loading = document.getElementById('zw-diff-modal-loading');
+    const error = document.getElementById('zw-diff-modal-error');
+    const errorText = error?.querySelector('p');
+    const grid = document.getElementById('zw-diff-modal-grid');
+    const before = document.getElementById('zw-diff-before');
+    const after = document.getElementById('zw-diff-after');
+
+    if (
+        !links.length ||
+        !modalTitle ||
+        !loading ||
+        !error ||
+        !errorText ||
+        !grid ||
+        !before ||
+        !after
+    ) {
+        return;
+    }
+
+    let activeRequest = 0;
+
+    for (const link of links) {
+        link.addEventListener('click', async (event) => {
+            event.preventDefault();
+
+            const postId = link.dataset.postId;
+            if (!postId) {
+                return;
+            }
+
+            const requestId = activeRequest + 1;
+            activeRequest = requestId;
+
+            link.setAttribute('aria-busy', 'true');
+            modalTitle.textContent =
+                config.strings?.loading ?? 'Verschillen laden...';
+            before.textContent = '';
+            after.textContent = '';
+            setDiffModalState('loading');
+            openDiffModal(link.href);
+
+            try {
+                const diff = await fetchDiff(postId);
+                if (requestId !== activeRequest) {
+                    return;
+                }
+
+                modalTitle.textContent =
+                    typeof diff.title === 'string'
+                        ? diff.title
+                        : (config.strings?.diffTitle ?? 'Verschillen');
+                before.innerHTML =
+                    typeof diff.before === 'string' ? diff.before : '';
+                after.innerHTML =
+                    typeof diff.after === 'string' ? diff.after : '';
+                setDiffModalState('ready');
+            } catch (fetchError) {
+                if (requestId !== activeRequest) {
+                    return;
+                }
+
+                modalTitle.textContent =
+                    config.strings?.diffTitle ?? 'Verschillen';
+                errorText.textContent =
+                    fetchError instanceof Error
+                        ? fetchError.message
+                        : (config.strings?.loadError ??
+                          'Verschillen konden niet worden geladen.');
+                setDiffModalState('error');
+            } finally {
+                link.removeAttribute('aria-busy');
+            }
+        });
+    }
+
+    function setDiffModalState(state) {
+        loading.hidden = state !== 'loading';
+        error.hidden = state !== 'error';
+        grid.hidden = state !== 'ready';
+    }
+}
+
+function openDiffModal(href) {
+    if (typeof window.tb_show !== 'function') {
+        return;
+    }
+
+    window.tb_show(
+        config.strings?.diffTitle ?? 'Verschillen',
+        href || '#TB_inline?width=800&height=600&inlineId=zw-diff-modal',
+    );
+}
+
+async function fetchDiff(postId) {
+    const body = new URLSearchParams();
+    body.set('action', config.ajaxAction);
+    body.set('nonce', config.nonce);
+    body.set('post_id', postId);
+
+    const response = await fetch(config.ajaxUrl, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        },
+        body,
+    });
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok || !payload?.success) {
+        throw new Error(
+            payload?.data?.message ??
+                config.strings?.requestFailed ??
+                'De aanvraag is mislukt.',
+        );
+    }
+
+    return payload.data ?? {};
 }

--- a/assets/audit.js
+++ b/assets/audit.js
@@ -71,6 +71,7 @@ function attachDiffHandlers() {
     }
 
     let activeRequest = 0;
+    let activeController = null;
 
     for (const link of links) {
         link.addEventListener('click', async (event) => {
@@ -83,7 +84,15 @@ function attachDiffHandlers() {
 
             const requestId = activeRequest + 1;
             activeRequest = requestId;
+            activeController?.abort();
+            activeController =
+                typeof window.AbortController === 'function'
+                    ? new window.AbortController()
+                    : null;
 
+            for (const busyLink of links) {
+                busyLink.removeAttribute('aria-busy');
+            }
             link.setAttribute('aria-busy', 'true');
             modalTitle.textContent =
                 config.strings?.loading ?? 'Verschillen laden...';
@@ -93,7 +102,7 @@ function attachDiffHandlers() {
             openDiffModal(link.href);
 
             try {
-                const diff = await fetchDiff(postId);
+                const diff = await fetchDiff(postId, activeController?.signal);
                 if (requestId !== activeRequest) {
                     return;
                 }
@@ -102,6 +111,7 @@ function attachDiffHandlers() {
                     typeof diff.title === 'string'
                         ? diff.title
                         : (config.strings?.diffTitle ?? 'Verschillen');
+                // Server response is sanitized by AuditPage::sanitize_diff_panel().
                 before.innerHTML =
                     typeof diff.before === 'string' ? diff.before : '';
                 after.innerHTML =
@@ -121,7 +131,10 @@ function attachDiffHandlers() {
                           'Verschillen konden niet worden geladen.');
                 setDiffModalState('error');
             } finally {
-                link.removeAttribute('aria-busy');
+                if (requestId === activeRequest) {
+                    activeController = null;
+                    link.removeAttribute('aria-busy');
+                }
             }
         });
     }
@@ -144,7 +157,7 @@ function openDiffModal(href) {
     );
 }
 
-async function fetchDiff(postId) {
+async function fetchDiff(postId, signal) {
     const body = new URLSearchParams();
     body.set('action', config.ajaxAction);
     body.set('nonce', config.nonce);
@@ -157,6 +170,7 @@ async function fetchDiff(postId) {
             'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
         },
         body,
+        signal,
     });
     const payload = await response.json().catch(() => null);
 

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -32,6 +32,13 @@ class AdminMenu {
 	private readonly SettingsPage $settings_page;
 
 	/**
+	 * Cached so page rendering and AJAX handlers share one audit page instance.
+	 *
+	 * @var AuditPage
+	 */
+	private readonly AuditPage $audit_page;
+
+	/**
 	 * Initializes the admin menu and registers WordPress hooks.
 	 *
 	 * @since 1.0.0
@@ -40,9 +47,11 @@ class AdminMenu {
 	 */
 	public function __construct( private readonly Logger $logger ) {
 		$this->settings_page = new SettingsPage( $this->logger );
+		$this->audit_page    = new AuditPage();
 
 		add_action( 'admin_menu', $this->add_admin_menu( ... ) );
 		add_action( 'admin_enqueue_scripts', $this->enqueue_admin_assets( ... ) );
+		add_action( 'wp_ajax_' . AuditPage::DIFF_AJAX_ACTION, array( $this->audit_page, 'handle_diff_ajax' ) );
 		add_action( 'zw_ttvgpt_diff_sanitizer_failed', $this->log_diff_sanitizer_failure( ... ), 10, 2 );
 	}
 
@@ -80,7 +89,7 @@ class AdminMenu {
 			__( 'Tekst TV Audit', 'zw-ttvgpt' ),
 			Constants::REQUIRED_CAPABILITY,
 			Constants::AUDIT_PAGE_SLUG,
-			array( new AuditPage(), 'render' )
+			array( $this->audit_page, 'render' )
 		);
 	}
 
@@ -99,8 +108,17 @@ class AdminMenu {
 			wp_enqueue_style( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.css', array(), $version );
 
 			$audit_config = array(
-				'baseUrl'  => admin_url( 'tools.php' ),
-				'pageSlug' => Constants::AUDIT_PAGE_SLUG,
+				'ajaxAction' => AuditPage::DIFF_AJAX_ACTION,
+				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+				'baseUrl'    => admin_url( 'tools.php' ),
+				'nonce'      => wp_create_nonce( AuditPage::DIFF_AJAX_NONCE_ACTION ),
+				'pageSlug'   => Constants::AUDIT_PAGE_SLUG,
+				'strings'    => array(
+					'diffTitle'     => __( 'Verschillen', 'zw-ttvgpt' ),
+					'loadError'     => __( 'Verschillen konden niet worden geladen.', 'zw-ttvgpt' ),
+					'loading'       => __( 'Verschillen laden...', 'zw-ttvgpt' ),
+					'requestFailed' => __( 'De aanvraag is mislukt.', 'zw-ttvgpt' ),
+				),
 			);
 			if ( $this->print_inline_config( 'zwTTVGPTAudit', $audit_config ) ) {
 				wp_enqueue_script_module( 'zw-ttvgpt-audit', ZW_TTVGPT_URL . 'assets/audit.js', array(), $version );

--- a/includes/admin/AdminMenu.php
+++ b/includes/admin/AdminMenu.php
@@ -111,7 +111,7 @@ class AdminMenu {
 				'ajaxAction' => AuditPage::DIFF_AJAX_ACTION,
 				'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
 				'baseUrl'    => admin_url( 'tools.php' ),
-				'nonce'      => wp_create_nonce( AuditPage::DIFF_AJAX_NONCE_ACTION ),
+				'nonce'      => wp_create_nonce( AuditPage::DIFF_AJAX_ACTION ),
 				'pageSlug'   => Constants::AUDIT_PAGE_SLUG,
 				'strings'    => array(
 					'diffTitle'     => __( 'Verschillen', 'zw-ttvgpt' ),

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -27,8 +27,7 @@ use ZW_TTVGPT_Core\Constants;
 class AuditPage {
 	use AjaxSecurity;
 
-	public const string DIFF_AJAX_ACTION       = 'zw_ttvgpt_audit_diff';
-	public const string DIFF_AJAX_NONCE_ACTION = 'zw_ttvgpt_audit_diff';
+	public const string DIFF_AJAX_ACTION = 'zw_ttvgpt_audit_diff';
 
 	/**
 	 * Retrieves validated filter parameters for audit page display.
@@ -67,7 +66,7 @@ class AuditPage {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
-	/** Keep page slices bounded so audit metadata stays reasonably cheap. */
+	/** Maximum audit rows rendered after month-wide categorization. */
 	private const int POSTS_PER_PAGE = 50;
 
 	/**
@@ -147,7 +146,7 @@ class AuditPage {
 	 * @return void
 	 */
 	public function handle_diff_ajax(): void {
-		$this->validate_ajax_request( self::DIFF_AJAX_NONCE_ACTION, Constants::REQUIRED_CAPABILITY );
+		$this->validate_ajax_request( self::DIFF_AJAX_ACTION, Constants::REQUIRED_CAPABILITY );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in validate_ajax_request().
 		$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
@@ -306,10 +305,10 @@ class AuditPage {
 					'bottom'
 				);
 				?>
-				</form>
-				<?php $this->render_diff_modal_container(); ?>
-			</div>
-			<?php
+			</form>
+			<?php $this->render_diff_modal_container(); ?>
+		</div>
+		<?php
 	}
 
 

--- a/includes/admin/AuditPage.php
+++ b/includes/admin/AuditPage.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use ZW_TTVGPT_Core\AjaxResponse;
+use ZW_TTVGPT_Core\AjaxSecurity;
 use ZW_TTVGPT_Core\AuditHelper;
 use ZW_TTVGPT_Core\AuditStatus;
 use ZW_TTVGPT_Core\Constants;
@@ -23,6 +25,11 @@ use ZW_TTVGPT_Core\Constants;
  * @since   1.0.0
  */
 class AuditPage {
+	use AjaxSecurity;
+
+	public const string DIFF_AJAX_ACTION       = 'zw_ttvgpt_audit_diff';
+	public const string DIFF_AJAX_NONCE_ACTION = 'zw_ttvgpt_audit_diff';
+
 	/**
 	 * Retrieves validated filter parameters for audit page display.
 	 *
@@ -60,7 +67,7 @@ class AuditPage {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
-	/** The page emits a hidden modal per row, so large pages are expensive. */
+	/** Keep page slices bounded so audit metadata stays reasonably cheap. */
 	private const int POSTS_PER_PAGE = 50;
 
 	/**
@@ -132,6 +139,60 @@ class AuditPage {
 		}
 
 		return $kses_out;
+	}
+
+	/**
+	 * Handles lazy loading for an audit diff modal.
+	 *
+	 * @return void
+	 */
+	public function handle_diff_ajax(): void {
+		$this->validate_ajax_request( self::DIFF_AJAX_NONCE_ACTION, Constants::REQUIRED_CAPABILITY );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in validate_ajax_request().
+		$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+		$post    = $post_id ? get_post( $post_id ) : null;
+
+		if ( ! $post instanceof \WP_Post || Constants::SUPPORTED_POST_TYPE !== $post->post_type || 'publish' !== $post->post_status ) {
+			AjaxResponse::error(
+				'invalid_post',
+				__( 'Artikel niet gevonden voor auditanalyse.', 'zw-ttvgpt' ),
+				404
+			);
+		}
+
+		AuditHelper::prime_meta_cache( array( $post_id ) );
+
+		if ( '1' !== (string) get_post_meta( $post_id, Constants::ACF_FIELD_IN_KABELKRANT, true ) ) {
+			AjaxResponse::error(
+				'invalid_post',
+				__( 'Artikel is niet beschikbaar in het auditlog.', 'zw-ttvgpt' ),
+				404
+			);
+		}
+
+		$analysis = AuditHelper::categorize_post( $post );
+		if ( AuditStatus::AiWrittenEdited !== $analysis['status'] ) {
+			AjaxResponse::error(
+				'no_diff',
+				__( 'Geen verschillen beschikbaar voor dit artikel.', 'zw-ttvgpt' ),
+				404
+			);
+		}
+
+		$diff = AuditHelper::generate_word_diff( $analysis['ai_content'], $analysis['human_content'] );
+
+		AjaxResponse::success(
+			array(
+				'title'  => sprintf(
+					/* translators: %s is the post title. */
+					__( 'Verschillen voor: %s', 'zw-ttvgpt' ),
+					get_the_title( $post_id )
+				),
+				'before' => self::sanitize_diff_panel( $diff['before'] ),
+				'after'  => self::sanitize_diff_panel( $diff['after'] ),
+			)
+		);
 	}
 
 	/**
@@ -245,9 +306,10 @@ class AuditPage {
 					'bottom'
 				);
 				?>
-			</form>
-		</div>
-		<?php
+				</form>
+				<?php $this->render_diff_modal_container(); ?>
+			</div>
+			<?php
 	}
 
 
@@ -584,11 +646,12 @@ class AuditPage {
 									</span>
 									<?php if ( AuditStatus::AiWrittenEdited === $status ) : ?>
 										<?php
-										$diff_url = '#TB_inline?width=800&height=600&inlineId=zw-diff-modal-' . $post->ID;
+										$diff_url = '#TB_inline?width=800&height=600&inlineId=zw-diff-modal';
 										?>
 										| <span class="view-diff">
 											<a href="<?php echo esc_attr( $diff_url ); ?>"
-												class="thickbox"
+												class="zw-audit-diff-link"
+												data-post-id="<?php echo esc_attr( (string) $post->ID ); ?>"
 												aria-label="<?php esc_attr_e( 'Toon verschillen tussen AI en bewerkte versie', 'zw-ttvgpt' ); ?>">
 												<?php esc_html_e( 'Verschillen', 'zw-ttvgpt' ); ?>
 											</a>
@@ -652,54 +715,47 @@ class AuditPage {
 				</tr>
 			</tfoot>
 		</table>
-		
-		<?php foreach ( $categorized_posts as $item ) : ?>
-			<?php if ( AuditStatus::AiWrittenEdited === $item['status'] ) : ?>
-				<?php
-				$post = $item['post'];
-				$diff = AuditHelper::generate_word_diff( $item['ai_content'], $item['human_content'] );
-				?>
-				<div id="zw-diff-modal-<?php echo esc_attr( (string) $post->ID ); ?>" class="zw-diff-modal">
-					<div class="wrap">
-						<?php
-						/* translators: %s is the post title. */
-						$modal_title = sprintf( __( 'Verschillen voor: %s', 'zw-ttvgpt' ), get_the_title( $post->ID ) );
-						?>
-						<h2><?php echo esc_html( $modal_title ); ?></h2>
+		<?php
+	}
 
-						<div class="zw-diff-modal-grid">
-							<div class="postbox">
-								<div class="postbox-header">
-									<h3 class="hndle"><?php esc_html_e( 'AI-versie', 'zw-ttvgpt' ); ?></h3>
-								</div>
-								<div class="inside">
-									<div class="zw-diff-panel">
-										<?php
-											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is sanitized by sanitize_diff_panel().
-											echo self::sanitize_diff_panel( $diff['before'] );
-										?>
-									</div>
-								</div>
-							</div>
+	/**
+	 * Renders the shared Thickbox container populated by audit.js.
+	 */
+	private function render_diff_modal_container(): void {
+		?>
+		<div id="zw-diff-modal" class="zw-diff-modal">
+			<div class="wrap">
+				<h2 id="zw-diff-modal-title"><?php esc_html_e( 'Verschillen laden', 'zw-ttvgpt' ); ?></h2>
 
-							<div class="postbox">
-								<div class="postbox-header">
-									<h3 class="hndle"><?php esc_html_e( 'Bewerkte versie', 'zw-ttvgpt' ); ?></h3>
-								</div>
-								<div class="inside">
-									<div class="zw-diff-panel">
-										<?php
-											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is sanitized by sanitize_diff_panel().
-											echo self::sanitize_diff_panel( $diff['after'] );
-										?>
-									</div>
-								</div>
-							</div>
+				<div id="zw-diff-modal-loading" class="zw-diff-modal-status" role="status" hidden>
+					<?php esc_html_e( 'Verschillen laden...', 'zw-ttvgpt' ); ?>
+				</div>
+
+				<div id="zw-diff-modal-error" class="notice notice-error inline" role="alert" hidden>
+					<p></p>
+				</div>
+
+				<div id="zw-diff-modal-grid" class="zw-diff-modal-grid" hidden>
+					<div class="postbox">
+						<div class="postbox-header">
+							<h3 class="hndle"><?php esc_html_e( 'AI-versie', 'zw-ttvgpt' ); ?></h3>
+						</div>
+						<div class="inside">
+							<div id="zw-diff-before" class="zw-diff-panel"></div>
+						</div>
+					</div>
+
+					<div class="postbox">
+						<div class="postbox-header">
+							<h3 class="hndle"><?php esc_html_e( 'Bewerkte versie', 'zw-ttvgpt' ); ?></h3>
+						</div>
+						<div class="inside">
+							<div id="zw-diff-after" class="zw-diff-panel"></div>
 						</div>
 					</div>
 				</div>
-			<?php endif; ?>
-		<?php endforeach; ?>
+			</div>
+		</div>
 		<?php
 	}
 }


### PR DESCRIPTION
## Summary
- render a single shared audit diff modal instead of one hidden modal per edited row
- add a secured admin-ajax endpoint that generates and sanitizes the diff for one post on demand
- wire audit.js to fetch the diff when "Verschillen" is clicked and show loading/error states

Closes #168

## Verification
- npm run lint
- vendor/bin/phpcs
- vendor/bin/phpstan analyse --memory-limit=2G