### PR TITLE
fix: log corrupted stored settings option (#173)

### DIFF
--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -135,6 +135,7 @@ class Helper {
 			}
 		}
 
+		// time() fallback is intentionally unlogged: debug-only path, cosmetic cache-busting impact only.
 		$debug_version = ZW_TTVGPT_VERSION . '.' . ( $latest > 0 ? $latest : time() );
 		return $debug_version;
 	}

--- a/includes/SettingsManager.php
+++ b/includes/SettingsManager.php
@@ -46,6 +46,17 @@ class SettingsManager {
 	private const string MODEL_MIGRATION_NOTICE_TRANSIENT = 'zw_ttvgpt_model_migration_notice';
 
 	/**
+	 * Transient key that throttles corrupted-settings logging.
+	 *
+	 * Without this, a non-array stored option would be re-detected and re-logged
+	 * on every request that misses the per-request object cache.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	private const string CORRUPT_SETTINGS_LOG_THROTTLE_TRANSIENT = 'zw_ttvgpt_corrupt_settings_logged';
+
+	/**
 	 * Clears the cached settings.
 	 *
 	 * @since 1.0.0
@@ -75,11 +86,42 @@ class SettingsManager {
 			Constants::get_default_settings()
 		);
 		if ( ! is_array( $settings ) ) {
+			self::log_corrupt_settings( $settings );
 			$settings = Constants::get_default_settings();
 		}
 
 		wp_cache_set( self::CACHE_KEY, $settings, self::CACHE_GROUP );
 		return $settings;
+	}
+
+	/**
+	 * Logs a corrupted (non-array) stored settings option, throttled to one entry per hour.
+	 *
+	 * Only safe metadata is recorded: option name, detected type, and string length for
+	 * string values. The raw value is never logged because a corrupted option may still
+	 * contain fragments of sensitive settings such as the API key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $settings The non-array value returned from get_option().
+	 */
+	private static function log_corrupt_settings( mixed $settings ): void {
+		if ( false !== get_transient( self::CORRUPT_SETTINGS_LOG_THROTTLE_TRANSIENT ) ) {
+			return;
+		}
+
+		$context = array(
+			'option_name'   => Constants::SETTINGS_OPTION_NAME,
+			'detected_type' => gettype( $settings ),
+		);
+		if ( is_string( $settings ) ) {
+			$context['string_length'] = strlen( $settings );
+		}
+
+		// Logger::error() writes unconditionally, so the debug-mode flag is irrelevant here.
+		( new Logger() )->error( 'Stored settings option is not an array; falling back to defaults', $context );
+
+		set_transient( self::CORRUPT_SETTINGS_LOG_THROTTLE_TRANSIENT, true, HOUR_IN_SECONDS );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Log via `Logger::error()` when `get_option( zw_ttvgpt_settings )` returns a non-array, before `SettingsManager::get_settings()` falls back to defaults.
- Throttle the log to once per hour via a transient, so persistent corruption does not log on every request that misses the per-request object cache.
- Only safe metadata is recorded: option name, detected type (`gettype()`), and string length for string values. The raw value is never logged because a corrupted option may still contain fragments of sensitive settings such as the API key.
- Document the `Helper::get_asset_version()` `time()` fallback as intentionally unlogged (debug-only, cosmetic cache-busting impact only).

Closes #173.

## Design notes
- `new Logger()` is instantiated locally on the corrupt-settings path. `Logger::error()` writes unconditionally, so the constructor's debug-mode flag is irrelevant here — no need to plumb a Logger instance into `SettingsManager` or introduce a static logger.
- No new `warning()` log level is introduced; `error()` is the right severity for stored-settings corruption.
- No cache changes needed. `get_settings()` already stores defaults in `wp_cache_set()` after the fallback, so repeated calls within the same request are covered. The transient covers repeated requests.

## Test plan
- [x] `vendor/bin/phpcs` passes
- [x] `vendor/bin/phpstan analyse --memory-limit=2G` passes (level 6)
- [x] `vendor/bin/phpunit` passes (134 tests)
- [ ] Manual: temporarily set `wp_options.zw_ttvgpt_settings` to a non-array value and confirm one `ZW_TTVGPT.ERROR` entry appears, with safe context only and no repeats within the hour.