### PR TITLE
feat: add native AI summary revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ WordPress-plugin die de GPT-modellen van OpenAI gebruikt om automatisch korte sa
 - Automatische detectie en ondersteuning voor de Chat Completions API en Responses API
 - Werkt met zowel de Block Editor (Gutenberg) als de Classic Editor
 - Auditfunctionaliteit met overzicht van alle samenvattingen en diff-weergave
+- Native WordPress-revisies voor AI-samenvattingen, inclusief model- en regio-metadata
 - Rate limiting (10 requests per minuut per gebruiker)
 - Uitgebreide foutafhandeling en validatie met consistente HTTP status codes
 - Integratie met WordPress-admin en ACF
@@ -77,6 +78,14 @@ OpenAI faseert self-serve fine-tuning uit. Nieuwe organisaties zonder eerder fin
 - Filter op wijzigingspercentage: Laag (≤20%), Gemiddeld (21-50%) of Hoog (>50%)
 - Bekijk de diff-weergave door op **Bekijk diff** te klikken
 
+### AI-versiehistorie
+- Elke succesvolle generatie wordt gemarkeerd voor de eerstvolgende normale WordPress-save. Die save wordt opgeslagen als native WordPress-revisie, zodat de revisie de actuele editorinhoud en de gegenereerde ACF-meta samen vastlegt.
+- Als het bericht na generatie niet wordt opgeslagen, vervalt deze tijdelijke markering automatisch na een uur.
+- De plugin gebruikt WordPress' postmeta-revisions framework voor de ACF-samenvatting, de opgeslagen AI-versie, het gebruikte model, de geselecteerde regio's en een AI-marker.
+- Open een bericht en gebruik de metabox **Tekst TV AI-versies** om eerdere AI-generaties in het WordPress Compare Revisions-scherm te bekijken of te herstellen.
+- Het Compare Revisions-scherm toont naast de normale revisievelden ook de Tekst TV-samenvatting, AI-versie, model, regio's en AI-marker.
+- De plugin wijzigt de sitebrede revisielimiet niet. WordPress blijft `WP_POST_REVISIONS` en eventuele bestaande revision-filters respecteren.
+
 ### Debuggen
 Schakel debugmodus in via **Instellingen** → **Tekst TV GPT** om gedetailleerde informatie te loggen:
 
@@ -120,6 +129,13 @@ npm run lint:fix                    # Biome auto-fix
 - **PHP:** WordPress Coding Standards (WPCS) + PHPStan level 6
 - **JavaScript/CSS:** Biome voor linting en formatting
 - **CI/CD:** GitHub Actions met automatische tests op PHP 8.3 en 8.4
+
+### Handmatige verificatie voor revisies
+Valideer na wijzigingen aan ACF of editor-integratie in beide editors:
+
+1. Genereer een samenvatting in de Block Editor, bewerk de samenvatting, herstel een eerdere AI-versie via **Tekst TV AI-versies** en controleer dat zowel het zichtbare samenvattingsveld als de opgeslagen AI-versie teruggezet zijn.
+2. Herhaal dezelfde flow in de Classic Editor.
+3. Controleer in het Compare Revisions-scherm dat model en regio's alleen zichtbaar zijn bij AI-generatie-revisies.
 
 ### Architectuur
 

--- a/includes/RevisionManager.php
+++ b/includes/RevisionManager.php
@@ -1,0 +1,489 @@
+<?php
+/**
+ * Native WordPress revision integration for AI summaries.
+ *
+ * @package ZW_TTVGPT
+ * @since   1.0.0
+ */
+
+namespace ZW_TTVGPT_Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers and annotates WordPress revisions that contain generated summaries.
+ *
+ * WordPress 6.4+ can revision post meta when keys opt in through
+ * register_post_meta() or the wp_post_revision_meta_keys filter. This manager
+ * keeps the plugin on that native path instead of maintaining a parallel
+ * version table in custom post meta.
+ *
+ * @package ZW_TTVGPT
+ * @since   1.0.0
+ */
+class RevisionManager {
+	/**
+	 * Meta key storing the model used for a generated summary.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	public const string META_MODEL = '_zw_ttvgpt_model';
+
+	/**
+	 * Meta key storing the selected regions as JSON.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	public const string META_REGIONS = '_zw_ttvgpt_regions';
+
+	/**
+	 * Meta key marking a revision as created by a successful AI generation.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	public const string META_IS_AI_GENERATED = '_zw_ttvgpt_is_ai_generated';
+
+	/**
+	 * Transient key prefix for pending AI revision markers.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	private const string PENDING_AI_REVISION_TRANSIENT_PREFIX = 'zw_ttvgpt_pending_revision_';
+
+	/**
+	 * Maximum time to wait for the post save that should create the AI revision.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	private const int PENDING_AI_REVISION_TTL = HOUR_IN_SECONDS;
+
+	/**
+	 * Maximum AI revisions shown in the editor metabox.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	private const int AI_REVISIONS_PER_PAGE = 5;
+
+	/**
+	 * Creates the revision manager and registers WordPress hooks.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param Logger $logger Logger instance for debug output.
+	 */
+	public function __construct( private readonly Logger $logger ) {
+		$this->register_revisioned_meta();
+
+		add_filter( 'wp_post_revision_meta_keys', $this->add_revision_meta_keys( ... ), 10, 2 );
+		add_action( '_wp_put_post_revision', $this->tag_revision( ... ), 11, 2 );
+		add_action( 'wp_after_insert_post', $this->clear_unresolved_pending_revision( ... ), 20, 3 );
+		add_filter( '_wp_post_revision_fields', $this->add_revision_fields( ... ), 10, 2 );
+
+		foreach ( array_keys( $this->get_revision_ui_fields() ) as $field ) {
+			add_filter( "_wp_post_revision_field_{$field}", $this->format_revision_field( ... ), 10, 4 );
+		}
+
+		add_action( 'add_meta_boxes_' . Constants::SUPPORTED_POST_TYPE, $this->add_ai_revisions_meta_box( ... ) );
+	}
+
+	/**
+	 * Stores generation metadata for the next native WordPress revision.
+	 *
+	 * The AJAX generation flow receives live editor content, but the post table
+	 * still contains the last saved content until the editor is saved. Creating a
+	 * revision directly from this AJAX request would snapshot stale post_content.
+	 * Instead, we store the generated meta now and let the next natural post save
+	 * create the revision after WordPress has persisted the editor content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int           $post_id Post ID that received the generated summary.
+	 * @param string        $model   OpenAI model used for generation.
+	 * @param array<string> $regions Region labels selected in the editor.
+	 */
+	public function record_generation( int $post_id, string $model, array $regions ): void {
+		update_post_meta( $post_id, self::META_MODEL, sanitize_text_field( $model ) );
+		update_post_meta( $post_id, self::META_REGIONS, $this->encode_regions( $regions ) );
+		update_post_meta( $post_id, self::META_IS_AI_GENERATED, '1' );
+
+		$pending_key = $this->get_pending_revision_transient_key( $post_id );
+		set_transient( $pending_key, '1', self::PENDING_AI_REVISION_TTL );
+		if ( '1' !== (string) get_transient( $pending_key ) ) {
+			$this->logger->error( 'Failed to store pending AI revision marker', array( 'post_id' => $post_id ) );
+		}
+
+		$this->logger->debug( 'AI summary metadata recorded for next post revision', array( 'post_id' => $post_id ) );
+	}
+
+	/**
+	 * Ensures plugin metadata is included in WordPress post-meta revisions.
+	 *
+	 * The register_post_meta() call is the primary registration path. This filter
+	 * keeps the keys present if another component adjusts the registry.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string> $keys      Existing revisioned meta keys.
+	 * @param string        $post_type Post type being revisioned.
+	 * @return array<string> Updated revisioned meta keys.
+	 */
+	public function add_revision_meta_keys( array $keys, string $post_type ): array {
+		if ( Constants::SUPPORTED_POST_TYPE !== $post_type ) {
+			return $keys;
+		}
+
+		$revisioned_keys = array_fill_keys( $keys, true );
+		foreach ( array_keys( $this->get_revisioned_meta_definitions() ) as $meta_key ) {
+			$revisioned_keys[ $meta_key ] = true;
+		}
+
+		return array_keys( $revisioned_keys );
+	}
+
+	/**
+	 * Marks the just-created revision as an AI generation only when appropriate.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $revision_id Revision ID.
+	 * @param int $post_id     Parent post ID.
+	 */
+	public function tag_revision( int $revision_id, int $post_id ): void {
+		if ( Constants::SUPPORTED_POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		if ( function_exists( 'wp_is_post_autosave' ) && wp_is_post_autosave( $revision_id ) ) {
+			$this->delete_ai_marker_from_revision( $revision_id );
+			return;
+		}
+
+		$pending_key            = $this->get_pending_revision_transient_key( $post_id );
+		$is_pending_ai_revision = '1' === (string) get_transient( $pending_key );
+		if ( ! $is_pending_ai_revision ) {
+			$this->delete_ai_marker_from_revision( $revision_id );
+			return;
+		}
+
+		delete_transient( $pending_key );
+
+		$this->logger->debug(
+			'AI summary revision tagged',
+			array(
+				'post_id'     => $post_id,
+				'revision_id' => $revision_id,
+			)
+		);
+	}
+
+	/**
+	 * Clears a pending marker when a save did not produce a revision.
+	 *
+	 * Core saves post update revisions before this cleanup runs. If our later
+	 * priority still sees the pending marker, revisions are disabled, the
+	 * revision hooks were removed, no revision was created, or the pending
+	 * marker outlived the editor session.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int    $post_id Post ID that was inserted or updated.
+	 * @param object $post    Post object that was inserted or updated.
+	 * @param bool   $update  Whether this insert updated an existing post.
+	 */
+	public function clear_unresolved_pending_revision( int $post_id, object $post, bool $update ): void {
+		if ( ! $update || Constants::SUPPORTED_POST_TYPE !== ( $post->post_type ?? '' ) ) {
+			return;
+		}
+
+		$pending_key = $this->get_pending_revision_transient_key( $post_id );
+		if ( '1' !== (string) get_transient( $pending_key ) ) {
+			return;
+		}
+
+		delete_transient( $pending_key );
+		$this->logger->error(
+			'AI summary revision marker cleared without a revision; revisions may be disabled or unavailable',
+			array( 'post_id' => $post_id )
+		);
+	}
+
+	/**
+	 * Adds ACF and AI metadata fields to the WordPress revision compare UI.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, string> $fields Revision fields keyed by field name.
+	 * @param array<string, mixed>  $post   Post array being revisioned.
+	 * @return array<string, string> Updated revision fields.
+	 */
+	public function add_revision_fields( array $fields, array $post ): array {
+		if ( Constants::SUPPORTED_POST_TYPE !== ( $post['post_type'] ?? '' ) ) {
+			return $fields;
+		}
+
+		return array_merge( $fields, $this->get_revision_ui_fields() );
+	}
+
+	/**
+	 * Formats plugin meta values before WordPress computes the revision diff.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed  $revision_field Raw revision field value.
+	 * @param string $field          Revision field name.
+	 * @param object $revision       Revision post object.
+	 * @param string $context        Diff context, either "from" or "to".
+	 * @return string Formatted value for diffing.
+	 */
+	public function format_revision_field( mixed $revision_field, string $field, object $revision, string $context ): string {
+		unset( $revision, $context );
+
+		if ( self::META_REGIONS === $field ) {
+			return implode( ', ', $this->decode_regions( (string) $revision_field ) );
+		}
+
+		if ( self::META_IS_AI_GENERATED === $field ) {
+			return '1' === (string) $revision_field ? __( 'Ja', 'zw-ttvgpt' ) : __( 'Nee', 'zw-ttvgpt' );
+		}
+
+		return is_scalar( $revision_field ) ? (string) $revision_field : '';
+	}
+
+	/**
+	 * Registers the editor sidebar metabox containing AI revision links.
+	 *
+	 * @since 1.0.0
+	 */
+	public function add_ai_revisions_meta_box(): void {
+		add_meta_box(
+			'zw-ttvgpt-ai-revisions',
+			__( 'Tekst TV AI-versies', 'zw-ttvgpt' ),
+			$this->render_ai_revisions_meta_box( ... ),
+			Constants::SUPPORTED_POST_TYPE,
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Renders links to AI-tagged revisions for the current post.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param object $post Current post object.
+	 */
+	public function render_ai_revisions_meta_box( object $post ): void {
+		$post_id   = isset( $post->ID ) ? (int) $post->ID : 0;
+		$revisions = $this->get_ai_revisions( $post_id );
+
+		if ( array() === $revisions ) {
+			echo '<p>' . esc_html__( 'Nog geen AI-versies opgeslagen.', 'zw-ttvgpt' ) . '</p>';
+			return;
+		}
+
+		echo '<ul>';
+		foreach ( $revisions as $revision ) {
+			$revision_id = (int) $revision->ID;
+			$model       = (string) get_post_meta( $revision_id, self::META_MODEL, true );
+			$link        = add_query_arg( array( 'revision' => $revision_id ), admin_url( 'revision.php' ) );
+			$date        = mysql2date(
+				sprintf(
+					'%1$s %2$s',
+					(string) get_option( 'date_format' ),
+					(string) get_option( 'time_format' )
+				),
+				(string) $revision->post_date
+			);
+			$label       = '' !== $model ? sprintf( '%1$s - %2$s', $date, $model ) : $date;
+
+			echo '<li><a href="' . esc_url( $link ) . '">' . esc_html( $label ) . '</a></li>';
+		}
+		echo '</ul>';
+	}
+
+	/**
+	 * Retrieves revisions explicitly tagged as AI-generated.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id Parent post ID.
+	 * @return array<int, object> Revision post objects keyed by revision ID.
+	 */
+	public function get_ai_revisions( int $post_id ): array {
+		if ( $post_id <= 0 || ! function_exists( 'wp_get_post_revisions' ) ) {
+			return array();
+		}
+
+		$revisions = wp_get_post_revisions(
+			$post_id,
+			array(
+				'check_enabled'  => false,
+				'meta_key'       => self::META_IS_AI_GENERATED,
+				'meta_value'     => '1',
+				'order'          => 'DESC',
+				'orderby'        => 'date ID',
+				'posts_per_page' => self::AI_REVISIONS_PER_PAGE,
+			)
+		);
+
+		return $revisions;
+	}
+
+	/**
+	 * Registers meta keys for native WordPress revision storage.
+	 *
+	 * @since 1.0.0
+	 */
+	private function register_revisioned_meta(): void {
+		foreach ( $this->get_revisioned_meta_definitions() as $meta_key => $args ) {
+			register_post_meta(
+				Constants::SUPPORTED_POST_TYPE,
+				$meta_key,
+				array_merge(
+					array(
+						'single'            => true,
+						'show_in_rest'      => false,
+						'revisions_enabled' => true,
+					),
+					$args
+				)
+			);
+		}
+	}
+
+	/**
+	 * Returns all meta keys that should be copied into WordPress revisions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array<string, mixed>> Meta definitions keyed by meta key.
+	 */
+	private function get_revisioned_meta_definitions(): array {
+		return array(
+			Constants::ACF_FIELD_HUMAN_CONTENT => array(
+				'type'        => 'string',
+				'label'       => __( 'Tekst TV samenvatting', 'zw-ttvgpt' ),
+				'description' => __( 'De actuele Tekst TV-samenvatting.', 'zw-ttvgpt' ),
+			),
+			Constants::ACF_FIELD_AI_CONTENT    => array(
+				'type'        => 'string',
+				'label'       => __( 'Tekst TV AI-versie', 'zw-ttvgpt' ),
+				'description' => __( 'De laatst door AI gegenereerde Tekst TV-samenvatting.', 'zw-ttvgpt' ),
+			),
+			self::META_MODEL                   => array(
+				'type'        => 'string',
+				'label'       => __( 'Tekst TV AI-model', 'zw-ttvgpt' ),
+				'description' => __( 'OpenAI-model waarmee de samenvatting is gemaakt.', 'zw-ttvgpt' ),
+			),
+			self::META_REGIONS                 => array(
+				'type'        => 'string',
+				'label'       => __( 'Tekst TV regio\'s', 'zw-ttvgpt' ),
+				'description' => __( 'Geselecteerde regio\'s tijdens generatie.', 'zw-ttvgpt' ),
+			),
+			self::META_IS_AI_GENERATED         => array(
+				'type'        => 'string',
+				'label'       => __( 'Tekst TV AI-generatie', 'zw-ttvgpt' ),
+				'description' => __( 'Marker die aangeeft dat deze revisie door AI-generatie is ontstaan.', 'zw-ttvgpt' ),
+			),
+		);
+	}
+
+	/**
+	 * Returns the meta fields shown in WordPress' revision compare UI.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, string> UI fields keyed by meta key.
+	 */
+	private function get_revision_ui_fields(): array {
+		return array(
+			Constants::ACF_FIELD_HUMAN_CONTENT => __( 'Tekst TV samenvatting', 'zw-ttvgpt' ),
+			Constants::ACF_FIELD_AI_CONTENT    => __( 'Tekst TV AI-versie', 'zw-ttvgpt' ),
+			self::META_MODEL                   => __( 'Tekst TV AI-model', 'zw-ttvgpt' ),
+			self::META_REGIONS                 => __( 'Tekst TV regio\'s', 'zw-ttvgpt' ),
+			self::META_IS_AI_GENERATED         => __( 'Tekst TV AI-generatie', 'zw-ttvgpt' ),
+		);
+	}
+
+	/**
+	 * Removes only the AI marker from revisions that were not just generated.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $revision_id Revision ID.
+	 */
+	private function delete_ai_marker_from_revision( int $revision_id ): void {
+		delete_post_meta( $revision_id, self::META_IS_AI_GENERATED );
+	}
+
+	/**
+	 * Builds the transient key for a post's pending AI revision marker.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Transient key.
+	 */
+	private function get_pending_revision_transient_key( int $post_id ): string {
+		return self::PENDING_AI_REVISION_TRANSIENT_PREFIX . $post_id;
+	}
+
+	/**
+	 * Sanitizes and JSON-encodes selected region labels.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string> $regions Raw region labels.
+	 * @return string JSON array of region labels.
+	 */
+	private function encode_regions( array $regions ): string {
+		$sanitized = array();
+		foreach ( $regions as $region ) {
+			$region = sanitize_text_field( $region );
+			if ( '' !== $region ) {
+				$sanitized[] = $region;
+			}
+		}
+
+		$sanitized = array_values( array_unique( $sanitized ) );
+		$encoded   = wp_json_encode( $sanitized );
+
+		return false === $encoded ? '[]' : $encoded;
+	}
+
+	/**
+	 * Decodes stored region labels.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $regions_json Stored JSON array.
+	 * @return array<string> Region labels.
+	 */
+	private function decode_regions( string $regions_json ): array {
+		if ( '' === trim( $regions_json ) ) {
+			return array();
+		}
+
+		$decoded = json_decode( $regions_json, true );
+		if ( ! is_array( $decoded ) ) {
+			return array();
+		}
+
+		$regions = array();
+		foreach ( $decoded as $region ) {
+			if ( is_scalar( $region ) && '' !== (string) $region ) {
+				$regions[] = (string) $region;
+			}
+		}
+
+		return $regions;
+	}
+}

--- a/includes/SummaryGenerator.php
+++ b/includes/SummaryGenerator.php
@@ -28,14 +28,16 @@ class SummaryGenerator {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param ApiHandler $api_handler API handler for OpenAI communication.
-	 * @param int        $word_limit  Maximum words allowed in summaries.
-	 * @param Logger     $logger      Logger instance for debugging.
+	 * @param ApiHandler      $api_handler      API handler for OpenAI communication.
+	 * @param int             $word_limit       Maximum words allowed in summaries.
+	 * @param Logger          $logger           Logger instance for debugging.
+	 * @param RevisionManager $revision_manager Native revision integration.
 	 */
 	public function __construct(
 		private readonly ApiHandler $api_handler,
 		private readonly int $word_limit,
-		private readonly Logger $logger
+		private readonly Logger $logger,
+		private readonly RevisionManager $revision_manager
 	) {
 		add_action( 'wp_ajax_zw_ttvgpt_generate', $this->handle_ajax_request( ... ) );
 	}
@@ -134,6 +136,8 @@ class SummaryGenerator {
 				500
 			);
 		}
+
+		$this->revision_manager->record_generation( $post_id, SettingsManager::get_model(), $regions );
 
 		$this->logger->debug( 'Summary generated for post ' . $post_id );
 

--- a/tests/RevisionManagerTest.php
+++ b/tests/RevisionManagerTest.php
@@ -1,0 +1,301 @@
+<?php
+declare(strict_types=1);
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
+
+	require_once __DIR__ . '/wp-load-helper.php';
+
+	$GLOBALS['zw_test_registered_post_meta'] = array();
+	$GLOBALS['zw_test_post_meta']           = array();
+	$GLOBALS['zw_test_post_types']          = array();
+	$GLOBALS['zw_test_autosave_revisions']  = array();
+
+	if ( ! function_exists( 'register_post_meta' ) ) {
+		function register_post_meta( string $post_type, string $meta_key, array $args ): bool {
+			$GLOBALS['zw_test_registered_post_meta'][ $post_type ][ $meta_key ] = $args;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'update_post_meta' ) ) {
+		function update_post_meta( int $post_id, string $meta_key, mixed $meta_value, mixed $prev_value = '' ): bool {
+			unset( $prev_value );
+
+			$GLOBALS['zw_test_post_meta'][ $post_id ][ $meta_key ] = $meta_value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'delete_post_meta' ) ) {
+		function delete_post_meta( int $post_id, string $meta_key, mixed $meta_value = '' ): bool {
+			unset( $meta_value );
+
+			unset( $GLOBALS['zw_test_post_meta'][ $post_id ][ $meta_key ] );
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'get_post_meta' ) ) {
+		function get_post_meta( int $post_id, string $meta_key = '', bool $single = false ): mixed {
+			$meta = $GLOBALS['zw_test_post_meta'][ $post_id ] ?? array();
+			if ( '' === $meta_key ) {
+				return $meta;
+			}
+
+			$value = $meta[ $meta_key ] ?? '';
+			return $single ? $value : array( $value );
+		}
+	}
+
+	if ( ! function_exists( 'get_post_type' ) ) {
+		function get_post_type( int $post_id ): string|false {
+			return $GLOBALS['zw_test_post_types'][ $post_id ] ?? 'post';
+		}
+	}
+
+	if ( ! function_exists( 'is_wp_error' ) ) {
+		function is_wp_error( mixed $thing ): bool {
+			return $thing instanceof WP_Error;
+		}
+	}
+
+	if ( ! function_exists( 'wp_is_post_autosave' ) ) {
+		function wp_is_post_autosave( mixed $post ): int|false {
+			$revision_id = is_object( $post ) && isset( $post->ID ) ? (int) $post->ID : (int) $post;
+			return $GLOBALS['zw_test_autosave_revisions'][ $revision_id ] ?? false;
+		}
+	}
+
+	if ( ! function_exists( 'add_meta_box' ) ) {
+		function add_meta_box(
+			string $id,
+			string $title,
+			callable $callback,
+			string|array|\WP_Screen|null $screen = null,
+			string $context = 'advanced',
+			string $priority = 'default',
+			array $callback_args = array()
+		): void {
+			unset( $id, $title, $callback, $screen, $context, $priority, $callback_args );
+		}
+	}
+}
+
+namespace ZW_TTVGPT_Core\Tests {
+
+	use PHPUnit\Framework\Attributes\CoversClass;
+	use PHPUnit\Framework\TestCase;
+	use ZW_TTVGPT_Core\Constants;
+	use ZW_TTVGPT_Core\RevisionManager;
+
+	#[CoversClass(RevisionManager::class)]
+	final class RevisionManagerTest extends TestCase {
+
+		protected function setUp(): void {
+			$GLOBALS['zw_test_registered_post_meta'] = array();
+			$GLOBALS['zw_test_post_meta']           = array();
+			$GLOBALS['zw_test_post_types']          = array( 123 => Constants::SUPPORTED_POST_TYPE );
+			$GLOBALS['zw_test_autosave_revisions']  = array();
+			$GLOBALS['zw_test_transients']          = array();
+			$GLOBALS['zw_test_set_transient_calls'] = array();
+
+			remove_all_filters( 'wp_post_revision_meta_keys' );
+			remove_all_actions( '_wp_put_post_revision' );
+			remove_all_actions( 'wp_after_insert_post' );
+			remove_all_filters( '_wp_post_revision_fields' );
+			remove_all_actions( 'add_meta_boxes_' . Constants::SUPPORTED_POST_TYPE );
+
+			foreach ( self::revisionUiFieldHooks() as $hook ) {
+				remove_all_filters( $hook );
+			}
+		}
+
+		protected function tearDown(): void {
+			remove_all_filters( 'wp_post_revision_meta_keys' );
+			remove_all_actions( '_wp_put_post_revision' );
+			remove_all_actions( 'wp_after_insert_post' );
+			remove_all_filters( '_wp_post_revision_fields' );
+			remove_all_actions( 'add_meta_boxes_' . Constants::SUPPORTED_POST_TYPE );
+
+			foreach ( self::revisionUiFieldHooks() as $hook ) {
+				remove_all_filters( $hook );
+			}
+		}
+
+		public function test_registers_revisioned_meta_for_acf_and_ai_generation_fields(): void {
+			new RevisionManager( new RecordingLogger() );
+
+			$registered = $GLOBALS['zw_test_registered_post_meta'][ Constants::SUPPORTED_POST_TYPE ] ?? array();
+
+			self::assertArrayHasKey( Constants::ACF_FIELD_HUMAN_CONTENT, $registered );
+			self::assertArrayHasKey( Constants::ACF_FIELD_AI_CONTENT, $registered );
+			self::assertArrayHasKey( RevisionManager::META_MODEL, $registered );
+			self::assertArrayHasKey( RevisionManager::META_REGIONS, $registered );
+			self::assertArrayHasKey( RevisionManager::META_IS_AI_GENERATED, $registered );
+			self::assertTrue( $registered[ RevisionManager::META_MODEL ]['revisions_enabled'] );
+			self::assertTrue( $registered[ Constants::ACF_FIELD_HUMAN_CONTENT ]['single'] );
+		}
+
+		public function test_revision_meta_filter_adds_keys_only_for_supported_post_type(): void {
+			new RevisionManager( new RecordingLogger() );
+
+			$post_keys = apply_filters( 'wp_post_revision_meta_keys', array( 'existing_key' ), Constants::SUPPORTED_POST_TYPE );
+			$page_keys = apply_filters( 'wp_post_revision_meta_keys', array( 'existing_key' ), 'page' );
+
+			self::assertContains( 'existing_key', $post_keys );
+			self::assertContains( RevisionManager::META_MODEL, $post_keys );
+			self::assertContains( Constants::ACF_FIELD_HUMAN_CONTENT, $post_keys );
+			self::assertSame( array( 'existing_key' ), $page_keys );
+		}
+
+		public function test_record_generation_marks_metadata_for_next_native_revision(): void {
+			$logger  = new RecordingLogger();
+			$manager = new RevisionManager( $logger );
+
+			$manager->record_generation(
+				123,
+				'gpt-5.5',
+				array( 'Bergen op Zoom', 'Roosendaal', 'Bergen op Zoom', '' )
+			);
+
+			self::assertSame( 'gpt-5.5', $GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_MODEL ] );
+			self::assertSame( '["Bergen op Zoom","Roosendaal"]', $GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_REGIONS ] );
+			self::assertSame( '1', $GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_IS_AI_GENERATED ] );
+			self::assertSame( '1', $GLOBALS['zw_test_transients']['zw_ttvgpt_pending_revision_123'] );
+			self::assertSame( HOUR_IN_SECONDS, $GLOBALS['zw_test_set_transient_calls'][0]['expiration'] );
+			self::assertSame( 'AI summary metadata recorded for next post revision', $logger->debugs[0]['message'] );
+		}
+
+		public function test_pending_revision_is_tagged_after_core_meta_copy(): void {
+			$logger  = new RecordingLogger();
+			$manager = new RevisionManager( $logger );
+
+			$manager->record_generation( 123, 'gpt-5.5', array( 'Roosendaal' ) );
+			self::copyGenerationMetaToRevision( 123, 9001 );
+
+			do_action( '_wp_put_post_revision', 9001, 123 );
+
+			self::assertArrayNotHasKey( 'zw_ttvgpt_pending_revision_123', $GLOBALS['zw_test_transients'] );
+			self::assertSame( '1', $GLOBALS['zw_test_post_meta'][9001][ RevisionManager::META_IS_AI_GENERATED ] );
+			self::assertSame( 'gpt-5.5', $GLOBALS['zw_test_post_meta'][9001][ RevisionManager::META_MODEL ] );
+			self::assertSame( '["Roosendaal"]', $GLOBALS['zw_test_post_meta'][9001][ RevisionManager::META_REGIONS ] );
+			self::assertSame( 'AI summary revision tagged', $logger->debugs[1]['message'] );
+		}
+
+		public function test_autosave_revision_does_not_consume_pending_marker(): void {
+			$logger  = new RecordingLogger();
+			$manager = new RevisionManager( $logger );
+
+			$manager->record_generation( 123, 'gpt-5.5', array( 'Roosendaal' ) );
+			self::copyGenerationMetaToRevision( 123, 800 );
+			$GLOBALS['zw_test_autosave_revisions'][800] = 123;
+
+			do_action( '_wp_put_post_revision', 800, 123 );
+
+			self::assertSame( '1', $GLOBALS['zw_test_transients']['zw_ttvgpt_pending_revision_123'] );
+			self::assertArrayNotHasKey( RevisionManager::META_IS_AI_GENERATED, $GLOBALS['zw_test_post_meta'][800] );
+
+			self::copyGenerationMetaToRevision( 123, 9001 );
+			do_action( '_wp_put_post_revision', 9001, 123 );
+
+			self::assertArrayNotHasKey( 'zw_ttvgpt_pending_revision_123', $GLOBALS['zw_test_transients'] );
+			self::assertSame( '1', $GLOBALS['zw_test_post_meta'][9001][ RevisionManager::META_IS_AI_GENERATED ] );
+		}
+
+		public function test_non_pending_revision_loses_only_ai_marker(): void {
+			new RevisionManager( new RecordingLogger() );
+
+			$GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_MODEL ]           = 'gpt-5.5';
+			$GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_REGIONS ]         = '["Roosendaal"]';
+			$GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_IS_AI_GENERATED ] = '1';
+			$GLOBALS['zw_test_post_meta'][700][ RevisionManager::META_MODEL ]           = 'gpt-5.5';
+			$GLOBALS['zw_test_post_meta'][700][ RevisionManager::META_REGIONS ]         = '["Roosendaal"]';
+			$GLOBALS['zw_test_post_meta'][700][ RevisionManager::META_IS_AI_GENERATED ] = '1';
+
+			do_action( '_wp_put_post_revision', 700, 123 );
+
+			self::assertSame( 'gpt-5.5', $GLOBALS['zw_test_post_meta'][700][ RevisionManager::META_MODEL ] );
+			self::assertSame( '["Roosendaal"]', $GLOBALS['zw_test_post_meta'][700][ RevisionManager::META_REGIONS ] );
+			self::assertArrayNotHasKey( RevisionManager::META_IS_AI_GENERATED, $GLOBALS['zw_test_post_meta'][700] );
+			self::assertSame( 'gpt-5.5', $GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_MODEL ] );
+			self::assertSame( '["Roosendaal"]', $GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_REGIONS ] );
+			self::assertSame( '1', $GLOBALS['zw_test_post_meta'][123][ RevisionManager::META_IS_AI_GENERATED ] );
+		}
+
+		public function test_unresolved_pending_marker_is_cleared_after_save_without_revision(): void {
+			$logger  = new RecordingLogger();
+			$manager = new RevisionManager( $logger );
+
+			$manager->record_generation( 123, 'gpt-5.5', array() );
+
+			do_action( 'wp_after_insert_post', 123, (object) array( 'post_type' => Constants::SUPPORTED_POST_TYPE ), true );
+
+			self::assertArrayNotHasKey( 'zw_ttvgpt_pending_revision_123', $GLOBALS['zw_test_transients'] );
+			self::assertCount( 1, $logger->errors );
+			self::assertSame( 'AI summary revision marker cleared without a revision; revisions may be disabled or unavailable', $logger->errors[0]['message'] );
+		}
+
+		public function test_adds_and_formats_revision_compare_fields(): void {
+			new RevisionManager( new RecordingLogger() );
+
+			$fields = apply_filters(
+				'_wp_post_revision_fields',
+				array( 'post_title' => 'Title' ),
+				array( 'post_type' => Constants::SUPPORTED_POST_TYPE )
+			);
+			$page_fields = apply_filters(
+				'_wp_post_revision_fields',
+				array( 'post_title' => 'Title' ),
+				array( 'post_type' => 'page' )
+			);
+			$regions = apply_filters(
+				'_wp_post_revision_field__zw_ttvgpt_regions',
+				'["Bergen op Zoom","Roosendaal"]',
+				RevisionManager::META_REGIONS,
+				(object) array( 'ID' => 9001 ),
+				'to'
+			);
+			$marker = apply_filters(
+				'_wp_post_revision_field__zw_ttvgpt_is_ai_generated',
+				'1',
+				RevisionManager::META_IS_AI_GENERATED,
+				(object) array( 'ID' => 9001 ),
+				'to'
+			);
+
+			self::assertArrayHasKey( Constants::ACF_FIELD_HUMAN_CONTENT, $fields );
+			self::assertArrayHasKey( RevisionManager::META_MODEL, $fields );
+			self::assertSame( array( 'post_title' => 'Title' ), $page_fields );
+			self::assertSame( 'Bergen op Zoom, Roosendaal', $regions );
+			self::assertSame( 'Ja', $marker );
+		}
+
+		/**
+		 * @return array<string>
+		 */
+		private static function revisionUiFieldHooks(): array {
+			return array(
+				'_wp_post_revision_field_' . Constants::ACF_FIELD_HUMAN_CONTENT,
+				'_wp_post_revision_field_' . Constants::ACF_FIELD_AI_CONTENT,
+				'_wp_post_revision_field_' . RevisionManager::META_MODEL,
+				'_wp_post_revision_field_' . RevisionManager::META_REGIONS,
+				'_wp_post_revision_field_' . RevisionManager::META_IS_AI_GENERATED,
+			);
+		}
+
+		private static function copyGenerationMetaToRevision( int $post_id, int $revision_id ): void {
+			foreach (
+				array(
+					RevisionManager::META_MODEL,
+					RevisionManager::META_REGIONS,
+					RevisionManager::META_IS_AI_GENERATED,
+				) as $meta_key
+			) {
+				$GLOBALS['zw_test_post_meta'][ $revision_id ][ $meta_key ] = $GLOBALS['zw_test_post_meta'][ $post_id ][ $meta_key ];
+			}
+		}
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __DIR__ ) . '/vendor/roots/wordpress-no-content/' );
 }
 
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 60 * MINUTE_IN_SECONDS );
+}
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/RecordingLogger.php';
 
@@ -34,6 +41,13 @@ if ( ! function_exists( 'set_transient' ) ) {
 			return false;
 		}
 		$GLOBALS['zw_test_transients'][ $key ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( string $key ): bool {
+		unset( $GLOBALS['zw_test_transients'][ $key ] );
 		return true;
 	}
 }

--- a/zw-ttvgpt.php
+++ b/zw-ttvgpt.php
@@ -35,6 +35,7 @@ use ZW_TTVGPT_Core\ApiHandler;
 use ZW_TTVGPT_Core\Constants;
 use ZW_TTVGPT_Core\Helper;
 use ZW_TTVGPT_Core\Logger;
+use ZW_TTVGPT_Core\RevisionManager;
 use ZW_TTVGPT_Core\SettingsManager;
 use ZW_TTVGPT_Core\SummaryGenerator;
 use ZW_TTVGPT_Core\Admin\AdminMenu;
@@ -46,17 +47,21 @@ use ZW_TTVGPT_Core\Admin\AdminMenu;
  */
 function zw_ttvgpt_init(): void {
 	$logger = new Logger( SettingsManager::is_debug_mode() );
+	$model  = SettingsManager::get_model();
+
+	$revision_manager = new RevisionManager( $logger );
 
 	$api_handler = new ApiHandler(
 		SettingsManager::get_api_key(),
-		SettingsManager::get_model(),
+		$model,
 		$logger
 	);
 
 	new SummaryGenerator(
 		$api_handler,
 		SettingsManager::get_word_limit(),
-		$logger
+		$logger,
+		$revision_manager
 	);
 
 	if ( is_admin() ) {


### PR DESCRIPTION
## Summary

Closes #179.

This PR adds native WordPress revision support for Tekst TV GPT summaries without building a parallel version store. The implementation uses WordPress' post meta revisions framework and keeps plugin metadata inside the existing revision/restore flow.

## Implementation

- Adds `RevisionManager` as the central revision integration point.
- Registers relevant meta via `register_post_meta(..., revisions_enabled => true)`:
  - ACF value for the visible Tekst TV summary.
  - ACF value for the stored AI version.
  - `_zw_ttvgpt_model`, `_zw_ttvgpt_regions`, `_zw_ttvgpt_is_ai_generated`.
- Keeps `wp_post_revision_meta_keys` as a fallback filter, but not as the primary opt-in path. This follows the correction in the first issue comment.
- Stores model, regions, and AI marker metadata after each successful generation.
- Marks the post with a one-hour transient, then lets the next natural WordPress post save create the revision. This avoids snapshotting stale `post_content` from the database during the AJAX generation request.
- Skips autosave revisions so an autosave cannot consume the pending AI marker. If core copied the AI marker to the autosave, the plugin removes it from that autosave revision.
- Tags only the next non-autosave save revision as an AI revision via `_wp_put_post_revision`.
- Removes only the AI marker from normal/non-pending revisions so manual saves are not counted as AI revisions, while parent-post model/region metadata remains available.
- Adds a late `wp_after_insert_post` cleanup for unresolved pending markers when no revision is created, for example when revisions are disabled or revision hooks were removed.
- Adds Tekst TV fields to the WordPress Compare Revisions screen via `_wp_post_revision_fields` and `_wp_post_revision_field_{$field}`.
- Adds a post editor metabox, **Tekst TV AI-versies**, with links to the latest AI revisions.
- Intentionally does not change `wp_revisions_to_keep`; the site default and existing filters remain authoritative.
- Documents usage and manual ACF/editor validation in the README.

## Design Notes

- The generation flow receives live editor content through AJAX, but WordPress still has the last saved `post_content` in the database until the user saves the post. Creating a revision directly during the AJAX request would produce a revision with stale post content and fresh summary metadata. Restoring that revision could roll back article edits. This PR therefore records the generated metadata immediately but waits for the next real WordPress save to create the revision.
- The pending marker is intentionally not revisioned. It is stored as a short-lived transient keyed by the parent post, so closing the editor without saving cannot incorrectly tag an unrelated save days later.
- Autosaves are ignored for AI tagging. The pending marker remains available for the following real save, while any AI marker copied to the autosave revision is removed.
- Model and regions are copied by WordPress core's `wp_save_revisioned_meta_fields()` hook at priority 10. The plugin hook runs at priority 11 and no longer performs redundant metadata writes to the revision.
- ACF reference meta keys are not revisioned. The value meta keys are revisioned; the parent ACF references remain untouched during restore.

## References

- https://make.wordpress.org/core/2023/10/24/framework-for-storing-revisions-of-post-meta-in-6-4/
- https://developer.wordpress.org/reference/hooks/wp_post_revision_meta_keys/
- https://developer.wordpress.org/reference/functions/register_post_meta/
- https://developer.wordpress.org/reference/hooks/_wp_put_post_revision/
- https://developer.wordpress.org/reference/hooks/_wp_post_revision_field_field/
- https://developer.wordpress.org/reference/hooks/wp_revisions_to_keep/

## Tests

- `vendor/bin/phpcs --standard=phpcs.xml.dist -s`
- `vendor/bin/phpstan analyse --memory-limit=2G`
- `vendor/bin/phpunit`
- `npm run lint`
- `git diff --check`

## Manual Verification After Deploy

ACF restore behavior can still depend on the active editor/ACF combination. Validate explicitly:

1. Block Editor: generate -> save/update the post -> edit summary -> restore an earlier AI version -> verify both the visible summary field and the stored AI version.
2. Classic Editor: repeat the same flow.
3. Compare Revisions: verify that model/regions are shown for AI generation revisions and that normal manual revisions are not listed in the **Tekst TV AI-versies** metabox.
4. Verify that generating without saving stores the summary but does not create a new revision until the post is saved.
5. Verify that an autosave after generation does not appear in **Tekst TV AI-versies** and that the following manual Update creates the AI revision.
6. Verify that generating and then leaving the editor without saving does not tag a later unrelated save after the one-hour marker expires.
