### PR TITLE
fix: include historical audit months

### DIFF
--- a/includes/AuditHelper.php
+++ b/includes/AuditHelper.php
@@ -94,14 +94,12 @@ class AuditHelper {
 	public static function get_most_recent_month(): ?array {
 		global $wpdb;
 
-		// Limit the scan to recent posts for audit performance.
 		$result = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT p.post_date
 				FROM {$wpdb->posts} p
 				WHERE p.post_status = %s
 				  AND p.post_type = %s
-				  AND p.post_date >= DATE_SUB(NOW(), INTERVAL 2 YEAR)
 				  AND EXISTS (
 					  SELECT 1 FROM {$wpdb->postmeta} pm1
 					  WHERE pm1.post_id = p.ID

--- a/tests/AuditHelperRecentMonthTest.php
+++ b/tests/AuditHelperRecentMonthTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZW_TTVGPT_Core\AuditHelper;
+
+#[CoversClass(AuditHelper::class)]
+final class AuditHelperRecentMonthTest extends TestCase {
+
+	private mixed $previous_wpdb;
+
+	protected function setUp(): void {
+		$this->previous_wpdb = $GLOBALS['wpdb'] ?? null;
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['wpdb'] = $this->previous_wpdb;
+	}
+
+	public function test_get_most_recent_month_includes_historical_audit_data(): void {
+		$wpdb            = new AuditHelperRecentMonthWpdbStub('2021-04-12 10:30:00');
+		$GLOBALS['wpdb'] = $wpdb;
+
+		self::assertSame(
+			array(
+				'year'  => 2021,
+				'month' => 4,
+			),
+			AuditHelper::get_most_recent_month()
+		);
+		self::assertStringNotContainsString( 'DATE_SUB', $wpdb->prepared_query );
+		self::assertStringNotContainsString( 'INTERVAL 2 YEAR', $wpdb->prepared_query );
+	}
+}
+
+final class AuditHelperRecentMonthWpdbStub {
+	public string $posts = 'wp_posts';
+	public string $postmeta = 'wp_postmeta';
+	public string $prepared_query = '';
+
+	public function __construct( private readonly ?string $result ) {}
+
+	public function prepare( string $query, mixed ...$args ): string {
+		$this->prepared_query = $query;
+		return $query;
+	}
+
+	public function get_var( string $query ): ?string {
+		return $this->result;
+	}
+}

--- a/tests/AuditHelperRecentMonthTest.php
+++ b/tests/AuditHelperRecentMonthTest.php
@@ -7,21 +7,19 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ZW_TTVGPT_Core\AuditHelper;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 #[CoversClass(AuditHelper::class)]
 final class AuditHelperRecentMonthTest extends TestCase {
 
-	private mixed $previous_wpdb;
-
-	protected function setUp(): void {
-		$this->previous_wpdb = $GLOBALS['wpdb'] ?? null;
-	}
-
 	protected function tearDown(): void {
-		$GLOBALS['wpdb'] = $this->previous_wpdb;
+		unset( $GLOBALS['wpdb'] );
 	}
 
 	public function test_get_most_recent_month_includes_historical_audit_data(): void {
-		$wpdb            = new AuditHelperRecentMonthWpdbStub('2021-04-12 10:30:00');
+		$wpdb            = new AuditHelperRecentMonthWpdbStub( '2021-04-12 10:30:00' );
 		$GLOBALS['wpdb'] = $wpdb;
 
 		self::assertSame(
@@ -34,14 +32,23 @@ final class AuditHelperRecentMonthTest extends TestCase {
 		self::assertStringNotContainsString( 'DATE_SUB', $wpdb->prepared_query );
 		self::assertStringNotContainsString( 'INTERVAL 2 YEAR', $wpdb->prepared_query );
 	}
+
+	public function test_get_most_recent_month_returns_null_when_no_matching_posts(): void {
+		$GLOBALS['wpdb'] = new AuditHelperRecentMonthWpdbStub( null );
+
+		self::assertNull( AuditHelper::get_most_recent_month() );
+	}
 }
 
 final class AuditHelperRecentMonthWpdbStub {
-	public string $posts = 'wp_posts';
-	public string $postmeta = 'wp_postmeta';
+	public readonly string $posts;
+	public readonly string $postmeta;
 	public string $prepared_query = '';
 
-	public function __construct( private readonly ?string $result ) {}
+	public function __construct( private readonly ?string $result ) {
+		$this->posts    = 'wp_posts';
+		$this->postmeta = 'wp_postmeta';
+	}
 
 	public function prepare( string $query, mixed ...$args ): string {
 		$this->prepared_query = $query;


### PR DESCRIPTION
## Summary
- remove the 2-year cutoff from audit most-recent-month detection
- add a regression test proving older audit data can still select the default audit month

## Verification
- vendor/bin/phpunit
- vendor/bin/phpcs
- vendor/bin/phpstan analyse --memory-limit=2G