### PR TITLE
fix: ensure generated summaries end with punctuation

### DIFF
--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -202,9 +202,19 @@ class Helper {
 			return $text;
 		}
 
-		$normalized = preg_replace( '/[,;:]+([\'"”’»)\]\}]*)$/u', '.$1', $text );
-		if ( null !== $normalized && $normalized !== $text ) {
-			return $normalized;
+		foreach (
+			array(
+				'/[,;:]+([\'"”’»]+)$/u' => '.$1',
+				'/([\'"”’»]+)[,;:]+$/u' => '.$1',
+				'/[,;:]+([)\]\}]+)$/u'  => '$1.',
+				'/([)\]\}]+)[,;:]+$/u'  => '$1.',
+				'/[,;:]+$/u'            => '.',
+			) as $pattern => $replacement
+		) {
+			$normalized = preg_replace( $pattern, $replacement, $text );
+			if ( null !== $normalized && $normalized !== $text ) {
+				return $normalized;
+			}
 		}
 
 		return $text . '.';

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -185,6 +185,32 @@ class Helper {
 	}
 
 	/**
+	 * Ensures generated summary text ends with sentence-ending punctuation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $text Summary text to normalize.
+	 * @return string Summary text with terminal punctuation.
+	 */
+	public static function ensure_terminal_period( string $text ): string {
+		$text = trim( $text );
+		if ( '' === $text ) {
+			return $text;
+		}
+
+		if ( 1 === preg_match( '/[.!?…][\'"”’»)\]\}]*$/u', $text ) ) {
+			return $text;
+		}
+
+		$normalized = preg_replace( '/[,;:]+([\'"”’»)\]\}]*)$/u', '.$1', $text );
+		if ( null !== $normalized && $normalized !== $text ) {
+			return $normalized;
+		}
+
+		return $text . '.';
+	}
+
+	/**
 	 * Tokenizes words in a text using a Unicode-aware pattern.
 	 *
 	 * A word is one or more Unicode letters, optionally followed by groups of a

--- a/includes/SummaryGenerator.php
+++ b/includes/SummaryGenerator.php
@@ -171,6 +171,7 @@ class SummaryGenerator {
 				return $result;
 			}
 
+			$result      = Helper::ensure_terminal_period( $result );
 			$last_result = $result;
 			$word_count  = Helper::count_words( $result );
 

--- a/tests/HelperTerminalPeriodTest.php
+++ b/tests/HelperTerminalPeriodTest.php
@@ -31,6 +31,11 @@ final class HelperTerminalPeriodTest extends TestCase {
 			'closing quote after punctuation is kept' => array( '"Het besluit is genomen."', '"Het besluit is genomen."' ),
 			'period is added after closing bracket'   => array( 'De weg gaat dicht (A58)', 'De weg gaat dicht (A58).' ),
 			'trailing comma becomes period'           => array( 'De vergadering start morgen,', 'De vergadering start morgen.' ),
+			'comma before quote becomes period'       => array( 'Hij zei "ja,"', 'Hij zei "ja."' ),
+			'comma after quote becomes period'        => array( 'Hij zei "ja",', 'Hij zei "ja."' ),
+			'colon before quote becomes period'       => array( 'Hij zei "ja:"', 'Hij zei "ja."' ),
+			'comma before bracket becomes period'     => array( 'De weg gaat dicht (A58,)', 'De weg gaat dicht (A58).' ),
+			'comma after bracket becomes period'      => array( 'De weg gaat dicht (A58),', 'De weg gaat dicht (A58).' ),
 		);
 	}
 }

--- a/tests/HelperTerminalPeriodTest.php
+++ b/tests/HelperTerminalPeriodTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace ZW_TTVGPT_Core\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ZW_TTVGPT_Core\Helper;
+
+#[CoversClass(Helper::class)]
+final class HelperTerminalPeriodTest extends TestCase {
+
+	#[DataProvider('terminalPeriodProvider')]
+	public function test_ensure_terminal_period( string $input, string $expected ): void {
+		self::assertSame( $expected, Helper::ensure_terminal_period( $input ) );
+	}
+
+	/**
+	 * @return array<string, array{string, string}>
+	 */
+	public static function terminalPeriodProvider(): array {
+		return array(
+			'empty string stays empty'                 => array( " \t\n", '' ),
+			'missing punctuation gets period'         => array( 'Het bericht stopt hier', 'Het bericht stopt hier.' ),
+			'text is trimmed before period is added'  => array( '  Het bericht stopt hier  ', 'Het bericht stopt hier.' ),
+			'existing period is preserved'            => array( 'Het bericht is klaar.', 'Het bericht is klaar.' ),
+			'existing question mark is preserved'     => array( 'Komt er extra toezicht?', 'Komt er extra toezicht?' ),
+			'existing exclamation mark is preserved'  => array( 'De weg is weer open!', 'De weg is weer open!' ),
+			'existing ellipsis is preserved'          => array( 'Het onderzoek loopt…', 'Het onderzoek loopt…' ),
+			'closing quote after punctuation is kept' => array( '"Het besluit is genomen."', '"Het besluit is genomen."' ),
+			'period is added after closing bracket'   => array( 'De weg gaat dicht (A58)', 'De weg gaat dicht (A58).' ),
+			'trailing comma becomes period'           => array( 'De vergadering start morgen,', 'De vergadering start morgen.' ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Add server-side normalization so generated summaries always end with sentence-ending punctuation.
- Apply the normalization before retry validation, saving to ACF, and returning the AJAX response.
- Add regression coverage for missing and existing terminal punctuation.

## Testing
- vendor/bin/phpunit
- vendor/bin/phpcs
- vendor/bin/phpstan analyse --memory-limit=1G