### PR TITLE
fix: retry transient OpenAI request failures

### DIFF
--- a/includes/ApiHandler.php
+++ b/includes/ApiHandler.php
@@ -350,17 +350,29 @@ class ApiHandler {
 			);
 		}
 
-		$response = wp_remote_post(
-			$endpoint,
-			array(
-				'timeout' => $timeout,
-				'headers' => array(
-					'Authorization' => 'Bearer ' . $this->api_key,
-					'Content-Type'  => 'application/json',
-				),
-				'body'    => $request_body,
-			)
+		$request_args = array(
+			'timeout' => $timeout,
+			'headers' => array(
+				'Authorization' => 'Bearer ' . $this->api_key,
+				'Content-Type'  => 'application/json',
+			),
+			'body'    => $request_body,
 		);
+		$response     = wp_remote_post( $endpoint, $request_args );
+
+		if ( is_wp_error( $response ) ) {
+			$this->logger->debug(
+				'API request failed, retrying',
+				array(
+					'model'         => $this->model,
+					'error_code'    => $response->get_error_code(),
+					'error_message' => $response->get_error_message(),
+				)
+			);
+			usleep( 500000 );
+
+			$response = wp_remote_post( $endpoint, $request_args );
+		}
 
 		if ( is_wp_error( $response ) ) {
 			$this->logger->error( 'API request failed: ' . $response->get_error_message() );

--- a/tests/ApiHandlerExtractTest.php
+++ b/tests/ApiHandlerExtractTest.php
@@ -16,6 +16,9 @@ final class ApiHandlerExtractTest extends TestCase {
 	private ApiHandler $handler;
 
 	protected function setUp(): void {
+		$GLOBALS['zw_test_http_requests']  = array();
+		$GLOBALS['zw_test_http_responses'] = array();
+
 		$this->logger  = new RecordingLogger();
 		$this->handler = new ApiHandler( 'sk-test', 'gpt-5.5', $this->logger );
 	}
@@ -181,5 +184,31 @@ final class ApiHandlerExtractTest extends TestCase {
 
 		self::assertInstanceOf( WP_Error::class, $result );
 		self::assertSame( 'invalid_response', $result->get_error_code() );
+	}
+
+	public function test_generate_summary_retries_transport_failure_once(): void {
+		$this->handler = new ApiHandler( 'sk-test', 'gpt-4.1-mini', $this->logger );
+
+		$GLOBALS['zw_test_http_responses'] = array(
+			new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out after 30001 milliseconds with 0 bytes received' ),
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode(
+					array(
+						'choices' => array(
+							array(
+								'message'       => array( 'content' => '  Retry gelukt.  ' ),
+								'finish_reason' => 'stop',
+							),
+						),
+					)
+				),
+			),
+		);
+
+		$result = $this->handler->generate_summary( 'Artikeltekst met voldoende inhoud.', 100 );
+
+		self::assertSame( 'Retry gelukt.', $result );
+		self::assertCount( 2, $GLOBALS['zw_test_http_requests'] );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -50,6 +50,55 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+$GLOBALS['zw_test_http_requests']  = array();
+$GLOBALS['zw_test_http_responses'] = array();
+
+if ( ! function_exists( 'wp_remote_post' ) ) {
+	/**
+	 * @param array<string, mixed> $args
+	 * @return array<string, mixed>|WP_Error
+	 */
+	function wp_remote_post( string $url, array $args = array() ): array|WP_Error {
+		$GLOBALS['zw_test_http_requests'][] = array(
+			'url'  => $url,
+			'args' => $args,
+		);
+
+		$response = array_shift( $GLOBALS['zw_test_http_responses'] );
+		return $response ?? array(
+			'response' => array( 'code' => 200 ),
+			'body'     => wp_json_encode(
+				array(
+					'choices' => array(
+						array(
+							'message'       => array( 'content' => 'summary' ),
+							'finish_reason' => 'stop',
+						),
+					),
+				)
+			),
+		);
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	/**
+	 * @param array<string, mixed> $response
+	 */
+	function wp_remote_retrieve_response_code( array $response ): int {
+		return isset( $response['response']['code'] ) ? (int) $response['response']['code'] : 0;
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	/**
+	 * @param array<string, mixed> $response
+	 */
+	function wp_remote_retrieve_body( array $response ): string {
+		return isset( $response['body'] ) && is_string( $response['body'] ) ? $response['body'] : '';
+	}
+}
+
 if ( ! function_exists( 'admin_url' ) ) {
 	function admin_url( string $path = '', string $scheme = 'admin' ): string {
 		return 'https://example.test/wp-admin/' . $path;
@@ -135,5 +184,11 @@ if ( ! class_exists( 'WP_Error' ) ) {
 		public function get_error_data(): mixed {
 			return $this->data;
 		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
 	}
 }


### PR DESCRIPTION
## Summary
- Retry transient WordPress HTTP transport failures once before surfacing an API network error.
- Reuse the same request args for the retry to keep behavior unchanged for successful calls and OpenAI HTTP responses.
- Add focused PHPUnit coverage for the retry path.

## Verification
- `vendor/bin/phpunit`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --memory-limit=2G`
- Secret scan of committed diff: clean