### PR TITLE
chore: require WordPress 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Code Quality](https://github.com/oszuidwest/zw-ttvgpt/actions/workflows/lint.yml/badge.svg)](https://github.com/oszuidwest/zw-ttvgpt/actions/workflows/lint.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![PHP Version](https://img.shields.io/badge/PHP-8.3%2B-blue.svg)](https://php.net)
-[![WordPress](https://img.shields.io/badge/WordPress-6.8%2B-blue.svg)](https://wordpress.org)
+[![WordPress](https://img.shields.io/badge/WordPress-7.0%2B-blue.svg)](https://wordpress.org)
 
 WordPress-plugin die de GPT-modellen van OpenAI gebruikt om automatisch korte samenvattingen van artikelen te genereren voor tekst-tv-uitzendingen ('kabelkrant') of teletekst.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ WordPress-plugin die de GPT-modellen van OpenAI gebruikt om automatisch korte sa
 ## Installatie en configuratie
 
 ### Vereisten
-- WordPress 6.8 of hoger
+- WordPress 7.0 of hoger
 - PHP 8.3 of hoger
 - Advanced Custom Fields (ACF) plugin
 - OpenAI API key

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,7 +16,7 @@
 
     <!-- Versions -->
     <config name="testVersion" value="8.3-8.4"/>
-    <config name="minimum_wp_version" value="6.8"/>
+    <config name="minimum_wp_version" value="7.0"/>
 
     <!-- Per-plugin -->
     <config name="text_domain" value="zw-ttvgpt"/>

--- a/zw-ttvgpt.php
+++ b/zw-ttvgpt.php
@@ -9,7 +9,7 @@
  * License: GPL-3.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: zw-ttvgpt
- * Requires at least: 6.8
+ * Requires at least: 7.0
  * Requires PHP: 8.3
  * Requires Plugins: advanced-custom-fields
  *


### PR DESCRIPTION
## Summary

- Raise the plugin header and documented minimum WordPress version from 6.8 to 7.0.

## Compatibility audit

- Reviewed the WordPress 6.7, 6.8, 6.9, and 7.0 developer field guides, including the current WordPress 7.0.2 maintenance release.
- Checked the plugin's WordPress API calls against Core functions removed or deprecated through 7.0.
- Ran Plugin Check 2.0.0 in update mode and reviewed the findings for runtime relevance.
- Activated the plugin alongside the complete oszuidwest plugin set on WordPress 7.0.2 and PHP 8.3.32.

The editor integration uses the public WordPress data and block-editor APIs and remains compatible with WordPress 7.

## Verification

- PHPUnit: 152 tests, 279 assertions
- PHPStan
- Biome lint
- PHP syntax check
- Plugin Check 2.0.0 review
- Full-set activation on WordPress 7.0.2 / PHP 8.3.32

## References

- [WordPress 6.7 field guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/)
- [WordPress 6.8 field guide](https://make.wordpress.org/core/2025/03/28/wordpress-6-8-field-guide/)
- [WordPress 6.9 field guide](https://make.wordpress.org/core/2025/11/25/wordpress-6-9-field-guide/)
- [WordPress 7.0 field guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/)
- [WordPress 7.0.2 release](https://wordpress.org/news/2026/07/wordpress-7-0-2-release/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the stated minimum WordPress requirement to version 7.0.

* **Compatibility**
  * The plugin now requires WordPress 7.0 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->